### PR TITLE
Add `image-has-alt` and better documentation of rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,20 @@ require "erblint-github/linters"
 ```yaml 
 ---
 linters:
+  GitHub::Accessibility::ImageHasAlt:
+    enabled: true
   GitHub::Accessibility::NoRedundantImageAlt:
     enabled: true
 ```
+
+### Rules
+
+- [GitHub::Accessibility::NoRedundantImageAlt](./docs/rules/accessibility/no-redundant-image-alt.md)
+- [GitHub::Accessibility::ImageHasAlt](./docs/rules/accessibility/image-has-alt.md)
 
 ## Testing
 
 ```
 bundle install
-bundle exec rake test
+bundle exec rake
 ```

--- a/docs/rules/accessibility/image-has-alt.md
+++ b/docs/rules/accessibility/image-has-alt.md
@@ -1,0 +1,25 @@
+# Image Has Alt
+
+## Rule Details
+
+`<img>` should have an alt prop with meaningful text or an empty string for decorative images.
+
+Learn more at [W3C WAI Images Tutorial](https://www.w3.org/WAI/tutorials/images/).
+
+👎 Examples of **incorrect** code for this rule:
+
+```erb
+<img src="logo.png">
+```
+
+👍 Examples of **correct** code for this rule:
+
+```erb
+<!-- good -->
+<img alt="" src="logo.png" >
+```
+
+```erb
+<!-- also good -->
+<a href='https://github.com/'><img alt="GitHub homepage" src="logo.png" ></a>
+```

--- a/docs/rules/accessibility/no-redundant-image-alt.md
+++ b/docs/rules/accessibility/no-redundant-image-alt.md
@@ -1,0 +1,26 @@
+# No redundant image alt
+
+## Rule Details
+
+`<img>` alt prop should not contain `image` or `picture` as screen readers already announce the element as an image.
+
+Learn more at [W3C WAI Images Tutorial](https://www.w3.org/WAI/tutorials/images/).
+
+👎 Examples of **incorrect** code for this rule:
+
+```erb
+<img alt="picture of Mona Lisa" src="monalisa.png">
+```
+
+👍 Examples of **correct** code for this rule:
+
+```erb
+<!-- good -->
+<img alt="Mona Lisa" src="monalisa.png">
+```
+
+
+```erb
+<!-- also good -->
+<img alt="The original painting of Mona Lisa hangs on the wall of Louvre museum" src="monalisa.png">
+```

--- a/lib/erblint-github/linters/github/accessibility/image_has_alt.rb
+++ b/lib/erblint-github/linters/github/accessibility/image_has_alt.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "../../custom_helpers"
+
+module ERBLint
+  module Linters
+    module GitHub
+      module Accessibility
+        class ImageHasAlt < Linter
+          include ERBLint::Linters::CustomHelpers
+          include LinterRegistry
+
+          MESSAGE = "<img> should have an alt prop with meaningful text or an empty string for decorative images"
+
+          def run(processed_source)
+            tags(processed_source).each do |tag|
+              next if tag.name != "img"
+              next if tag.closing?
+
+              alt = possible_attribute_values(tag, "alt")
+
+              generate_offense(self.class, processed_source, tag) if alt.empty?
+            end
+
+            rule_disabled?(processed_source)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/linters/accessibility/image_has_alt_test.rb
+++ b/test/linters/accessibility/image_has_alt_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImageHasAltTest < LinterTestCase
+  def linter_class
+    ERBLint::Linters::GitHub::Accessibility::ImageHasAlt
+  end
+
+  def test_warns_if_image_has_no_alt_attribute
+    @file = "<img></img>"
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
+  def test_does_not_warn_if_image_has_alt_attribute_set_to_empty_string
+    @file = "<img alt=''></img>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+
+  def test_does_not_warn_if_image_has_alt_attribute_set_to_string
+    @file = "<img alt='monalisa'></img>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+end


### PR DESCRIPTION
Closes https://github.com/github/erblint-github/issues/1

### Changes

- Adds `GitHub::Accessibility::ImageHasAlt`. When enabled, this rule will raise a lint error if an `img` tag is found without an `alt` attribute set. The `alt` attribute must be set to an empty string if the image is decorative, or a string that describes either the image, or the functional use. 
- Adds better documentation of lint rules, inspired by [eslint-plugin-github](https://github.com/github/eslint-plugin-github/). 