### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @github/accessibility-reviewers


### PR DESCRIPTION
This adds a CODEOWNERS file so @github/accessibility-reviewers is auto-assigned to PRs in this repo.