### PR TITLE
Add test to make sure `<details>` elements have a `<summary>` element

### DIFF
--- a/lib/erblint-github/linters/github/accessibility/details_has_summary.rb
+++ b/lib/erblint-github/linters/github/accessibility/details_has_summary.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../../custom_helpers"
+
+module ERBLint
+  module Linters
+    module GitHub
+      module Accessibility
+        class DetailsHasSummary < Linter
+          include ERBLint::Linters::CustomHelpers
+          include LinterRegistry
+
+          MESSAGE = "<details> elements need to have explict <summary> elements"
+
+          def run(processed_source)
+            tags(processed_source).each do |tag|
+              next if tag.closing?
+              next unless tag.name == "details"
+
+              # Find the details element index in the AST
+              index = processed_source.ast.to_a.find_index(tag.node)
+
+              # Get the next element in the AST
+              next_node = processed_source.ast.to_a[index + 1]
+              next_tag = BetterHtml::Tree::Tag.from_node(next_node)
+
+              # If the next element is a summary, we're good
+              next if next_tag.name == "summary"
+
+              generate_offense(self.class, processed_source, tag)
+            end
+
+            rule_disabled?(processed_source)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/linters/accessibility/details_has_summary_test.rb
+++ b/test/linters/accessibility/details_has_summary_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DetailsHasSummary < LinterTestCase
+  def linter_class
+    ERBLint::Linters::GitHub::Accessibility::DetailsHasSummary
+  end
+
+  def test_warns_if_details_doesnt_have_a_summary
+    @file = "<details>I don't have a summary element</details>"
+    @linter.run(processed_source)
+
+    assert_equal @linter.offenses.count, 1
+  end
+
+  def test_does_not_warn_if_only_disabled_attribute_is_set
+    @file = "<details><summary>Expand me!</summary><button>Surprise button!</button></details>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+end


### PR DESCRIPTION
Hey 👋🏻 

Here's a rule that makes sure that `<details>` elements have a `<summary>` element as well. While a `<details>` element doesn't _need_ to have a `<summary>` element, it's good practice to provide one and not let the user agent inject one. Details elements should have a descriptive `<summary>` element instead.

I haven't written a rule that checks the child elements of a element before so I'm happy to make revisions if I'm doing the child querying incorrectly.