### PR TITLE
Refine generic link text linter logic

### DIFF
--- a/docs/rules/accessibility/avoid-generic-link-text-counter.md
+++ b/docs/rules/accessibility/avoid-generic-link-text-counter.md
@@ -11,6 +11,24 @@ Additionally, generic link text can also problematic for heavy zoom users where 
 Ensure that your link text is descriptive and the purpose of the link is clear even when read out of context of surrounding text. 
 Learn more about how to write descriptive link text at [Access Guide: Write descriptive link text](https://www.accessguide.io/guide/descriptive-link-text)
 
+### Use of ARIA attributes
+
+It is acceptable to use `aria-label` or `aria-labelledby` to provide a more descriptive text in some cases. As note above, this is not the preferred solution and one should strive to make the visible text to be as descriptive as the design allows.
+
+If you _must_ use this technique, you need to ensure that the accessible name completely contains the visible text. Otherwise, this is a failure of [SC 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).
+
+This is not acceptable:
+```
+<a href="..." aria-label="GitHub announces something">Read more</a>
+```
+
+This is acceptable:
+```
+<a href="..." aria-label="Read more about the new accesibility feature">Read more</a>
+```
+
+This linter will raise a flag when it is able to detect that a generic link has an accessible name that doesn't contain the visible text. Due to the restrictions of static code analysis, this may not catch all violations so it is important to supplement this check with other techniques like browser tests. For instance, ERB lint will not be able to evaluate the accessible name set by `aria-labelledby` or when a variable is set to `aria-label` since this requires runtime evaluation.
+
 ## Resources
 
 - [Primer: Links](https://primer.style/design/accessibility/links)
@@ -43,6 +61,11 @@ Learn more about how to write descriptive link text at [Access Guide: Write desc
 <%= link_to "Learn more", "#" %>
 ```
 
+```erb
+<!-- also bad -->
+<a href="github.com/about" aria-label="Why dogs are awesome">Read more</a>
+```
+
 ### **Correct** code for this rule  👍
 
 ```erb
@@ -51,4 +74,9 @@ Learn more about how to write descriptive link text at [Access Guide: Write desc
 
 ```erb
 <a href="github.com/new">Create a new repository</a>
+```
+
+```erb
+<!-- not ideal but won't be flagged -->
+<a aria-label="Learn more about GitHub" href="github.com/about">Learn more</a>
 ```

--- a/docs/rules/accessibility/avoid-generic-link-text-counter.md
+++ b/docs/rules/accessibility/avoid-generic-link-text-counter.md
@@ -11,6 +11,8 @@ Additionally, generic link text can also problematic for heavy zoom users where 
 Ensure that your link text is descriptive and the purpose of the link is clear even when read out of context of surrounding text. 
 Learn more about how to write descriptive link text at [Access Guide: Write descriptive link text](https://www.accessguide.io/guide/descriptive-link-text)
 
+### Use of ARIA attributes
+
 If you _must_ use ARIA to replace the visible link text, include the visible text at the beginning.
 
 For example, on a pricing plans page, the following are good:

--- a/docs/rules/accessibility/avoid-generic-link-text-counter.md
+++ b/docs/rules/accessibility/avoid-generic-link-text-counter.md
@@ -11,23 +11,31 @@ Additionally, generic link text can also problematic for heavy zoom users where 
 Ensure that your link text is descriptive and the purpose of the link is clear even when read out of context of surrounding text. 
 Learn more about how to write descriptive link text at [Access Guide: Write descriptive link text](https://www.accessguide.io/guide/descriptive-link-text)
 
-### Use of ARIA attributes
+If you _must_ use ARIA to replace the visible link text, include the visible text at the beginning.
 
-It is acceptable to use `aria-label` or `aria-labelledby` to provide a more descriptive text in some cases. As note above, this is not the preferred solution and one should strive to make the visible text to be as descriptive as the design allows.
+For example, on a pricing plans page, the following are good:
+- Visible text: `Learn more`
+- Accessible label: `Learn more about GitHub pricing plans`
 
-If you _must_ use this technique, you need to ensure that the accessible name completely contains the visible text. Otherwise, this is a failure of [SC 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).
-
-This is not acceptable:
-```
-<a href="..." aria-label="GitHub announces something">Read more</a>
-```
-
-This is acceptable:
-```
-<a href="..." aria-label="Read more about the new accesibility feature">Read more</a>
+Accessible ✅
+```html
+<a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</a>
 ```
 
-This linter will raise a flag when it is able to detect that a generic link has an accessible name that doesn't contain the visible text. Due to the restrictions of static code analysis, this may not catch all violations so it is important to supplement this check with other techniques like browser tests. For instance, ERB lint will not be able to evaluate the accessible name set by `aria-labelledby` or when a variable is set to `aria-label` since this requires runtime evaluation.
+Inaccessible 🚫
+```html
+<a href="..." aria-label="GitHub pricing plans">Learn more</a>
+```
+
+Including the visible text in the ARIA label satisfies [SC 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).
+
+#### False negatives
+
+Caution: because of the restrictions of static code analysis, we may not catch all violations.
+
+Please perform browser tests and spot checks:
+- when `aria-label` is set dynamically
+- when using `aria-labelledby`
 
 ## Resources
 

--- a/docs/rules/accessibility/avoid-generic-link-text-counter.md
+++ b/docs/rules/accessibility/avoid-generic-link-text-counter.md
@@ -66,6 +66,11 @@ This linter will raise a flag when it is able to detect that a generic link has 
 <a href="github.com/about" aria-label="Why dogs are awesome">Read more</a>
 ```
 
+```erb
+<!-- also bad. `aria-describedby` does not count towards accessible name of an element-->
+<a href="github.com/about" aria-describedby="element123">Read more</a>
+```
+
 ### **Correct** code for this rule  👍
 
 ```erb

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -116,7 +116,7 @@ module ERBLint
           end
 
           def valid_accessible_name?(aria_label, text)
-            aria_label.start_with?(text)
+            aria_label.downcase.include?(text.downcase)
           end
 
           # Checks if Ruby node contains `aria-label` or `aria-labelledby`

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -36,8 +36,15 @@ module ERBLint
                 prev_node_tag = BetterHtml::Tree::Tag.from_node(prev_node)
                 next_node_tag = BetterHtml::Tree::Tag.from_node(next_node)
 
+                aria_label = possible_attribute_values(prev_node_tag, "aria-label")
+                aria_labelledby = possible_attribute_values(prev_node_tag, "aria-labelledby")
+
                 # We only report if the text is nested between two link tags.
                 if link_tag?(prev_node_tag) && link_tag?(next_node_tag) && next_node_tag.closing?
+                  # Cannot statically check label from aria-labelledby or label from variable aria-label so we skip
+                  next if aria_labelledby.present? || (aria_label.present? && aria_label.join.include?("<%="))
+                  next if aria_label.present? && valid_accessible_name?(aria_label.join, text)
+
                   range = prev_node_tag.loc.begin_pos...text_node_tag.loc.end_pos
                   source_range = processed_source.to_source_range(range)
                   generate_offense_from_source_range(self.class, source_range)
@@ -54,11 +61,34 @@ module ERBLint
               send_node = ruby_node&.descendants(:send)&.first
               next unless send_node.methods.include?(:method_name) && send_node.method_name == :link_to
 
+              banned_text = nil
+
               send_node.child_nodes.each do |child_node|
-                if child_node.methods.include?(:type) && child_node.type == :str && banned_text?(child_node.children.join)
-                  tag = BetterHtml::Tree::Tag.from_node(code_node)
-                  generate_offense(self.class, processed_source, tag)
+                banned_text = child_node.children.join if child_node.methods.include?(:type) && child_node.type == :str && banned_text?(child_node.children.join)
+
+                next unless banned_text.present? && child_node.methods.include?(:type) && child_node.type == :hash
+
+                child_node.descendants(:pair).each do |pair_node|
+                  next unless pair_node.children.first.type?(:sym)
+
+                  # Don't flag if link has aria-labelledby which we cannot evaluate with ERB alone.
+                  banned_text = nil if pair_node.children.first.children.join == "aria-labelledby" || pair_node.children.first.children.join == "aria-label"
+                  next unless pair_node.children.first.children.join == "aria-label"
+
+                  aria_label_value_node = pair_node.children[1]
+                  if aria_label_value_node.type == :str
+                    binding.irb
+                    aria_label_text = aria_label_value_node.children.join
+                    banned_text = nil if valid_accessible_name?(aria_label_text, banned_text)
+                  else
+                    # Don't flag if aria-label is not string (e.g. is a variable) since we cannot evaluate with ERB alone.
+                    banned_text = nil
                   end
+                end
+              end
+              if banned_text.present?
+                tag = BetterHtml::Tree::Tag.from_node(code_node)
+                generate_offense(self.class, processed_source, tag)
               end
             end
             counter_correct?(processed_source)
@@ -82,6 +112,12 @@ module ERBLint
 
           def banned_text?(text)
             BANNED_GENERIC_TEXT.map(&:downcase).include?(text.downcase)
+          end
+
+          # We flag if accessible name does not start with visible text.
+          # Related: Success Criteria 2.5.3
+          def valid_accessible_name?(accessible_name, visible_text)
+            accessible_name.downcase.start_with?(visible_text.downcase)
           end
 
           def extract_ruby_node(source)

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -42,10 +42,10 @@ module ERBLint
 
                 # Checks if nested between two link tags.
                 if link_tag?(prev_node_tag) && link_tag?(next_node_tag) && next_node_tag.closing?
-                  # We skip because we cannot reliably check accessible name given aria-labelledby, or an aria-label that is set to a variable
+                  # Skip because we cannot reliably check accessible name from aria-labelledby, or an aria-label that is set to a variable
                   # with static code analysis.
                   next if aria_labelledby.present? || (aria_label.present? && aria_label.join.include?("<%="))
-                  # We skip because aria-label contains visible text. Relates to Success Criterion 2.5.3: Label in Name
+                  # Skip because aria-label starts with visible text which we allow. Related to Success Criterion 2.5.3: Label in Name
                   next if aria_label.present? && valid_accessible_name?(aria_label.join, text)
 
                   range = prev_node_tag.loc.begin_pos...text_node_tag.loc.end_pos
@@ -81,7 +81,7 @@ module ERBLint
                     end
                   end
 
-                  # Skip if `link_to` has `aria-labelledby` or `aria-label` which we cannot be evaluated accurately with ERB lint alone.
+                  # Skips if `link_to` has `aria-labelledby` or `aria-label` which we cannot be evaluated accurately with ERB lint alone.
                   # ERB lint removes Ruby string interpolation so the `aria-label` for "<%= link_to 'Learn more', "aria-label": "Learn #{@some_variable}" %>" will
                   # only be `Learn` which is unreliable so we can't do checks :(
                   banned_text = nil if pair_node.children.first.children.join == "aria-labelledby" || pair_node.children.first.children.join == "aria-label"

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -68,8 +68,9 @@ module ERBLint
 
               send_node.child_nodes.each do |child_node|
                 banned_text = child_node.children.join if child_node.methods.include?(:type) && child_node.type == :str && banned_text?(child_node.children.join)
+                next if banned_text.blank?
 
-                next unless banned_text.present? && child_node.methods.include?(:type) && child_node.type == :hash
+                next unless child_node.methods.include?(:type) && child_node.type == :hash
 
                 child_node.descendants(:pair).each do |pair_node|
                   next unless pair_node.children.first.type?(:sym)
@@ -82,7 +83,7 @@ module ERBLint
 
                   # Skip if `link_to` has `aria-labelledby` or `aria-label` which we cannot be evaluated accurately with ERB lint alone.
                   # ERB lint removes Ruby string interpolation so the `aria-label` for "<%= link_to 'Learn more', "aria-label": "Learn #{@some_variable}" %>" will
-                  # be `Learn` which is unreliable so we have to skip entirely unlike with HTML :(
+                  # only be `Learn` which is unreliable so we can't do checks :(
                   banned_text = nil if pair_node.children.first.children.join == "aria-labelledby" || pair_node.children.first.children.join == "aria-label"
                 end
               end

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -148,7 +148,9 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
   def test_handles_files_with_various_links
     @file = <<~ERB
       <p>
-        <a aria-labelledby='someElement'>Click here</a>
+        <a href="github.com" aria-label='Click here to learn more'>Click here</a>
+        <a href="github.com" aria-label='Some totally different text'>Click here</a>
+        <a href="github.com" aria-labelledby='someElement'>Click here</a>
       </p>
       <p>
         <%= link_to "learn more", billing_path, "aria-label": "something" %>
@@ -160,7 +162,8 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     @linter.run(processed_source)
 
     refute_empty @linter.offenses
-    assert_equal 3, @linter.offenses.count
+    # 3 offenses, 1 related to matching counter comment not present despite violations
+    assert_equal 4, @linter.offenses.count
   end
 
   def test_does_not_warns_if_element_has_correct_counter_comment

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -7,106 +7,106 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     ERBLint::Linters::GitHub::Accessibility::AvoidGenericLinkTextCounter
   end
 
-  # def test_warns_when_link_text_is_click_here
-  #   @file = "<a>Click here</a>"
-  #   @linter.run(processed_source)
+  def test_warns_when_link_text_is_click_here
+    @file = "<a>Click here</a>"
+    @linter.run(processed_source)
 
-  #   refute_empty @linter.offenses
-  # end
+    refute_empty @linter.offenses
+  end
 
-  # def test_warns_when_link_text_is_learn_more
-  #   @file = "<a>Learn more</a>"
-  #   @linter.run(processed_source)
+  def test_warns_when_link_text_is_learn_more
+    @file = "<a>Learn more</a>"
+    @linter.run(processed_source)
 
-  #   refute_empty @linter.offenses
-  # end
+    refute_empty @linter.offenses
+  end
 
-  # def test_warns_when_link_text_is_read_more
-  #   @file = "<a>Read more</a>"
-  #   @linter.run(processed_source)
+  def test_warns_when_link_text_is_read_more
+    @file = "<a>Read more</a>"
+    @linter.run(processed_source)
 
-  #   refute_empty @linter.offenses
-  # end
+    refute_empty @linter.offenses
+  end
 
-  # def test_warns_when_link_text_is_more
-  #   @file = "<a>More</a>"
-  #   @linter.run(processed_source)
+  def test_warns_when_link_text_is_more
+    @file = "<a>More</a>"
+    @linter.run(processed_source)
 
-  #   refute_empty @linter.offenses
-  # end
+    refute_empty @linter.offenses
+  end
 
-  # def test_warns_when_link_text_is_link
-  #   @file = "<a>Link</a>"
-  #   @linter.run(processed_source)
+  def test_warns_when_link_text_is_link
+    @file = "<a>Link</a>"
+    @linter.run(processed_source)
 
-  #   refute_empty @linter.offenses
-  # end
+    refute_empty @linter.offenses
+  end
 
-  # def test_does_not_warn_when_banned_text_is_part_of_more_text
-  #   @file = "<a>Learn more about GitHub Stars</a>"
-  #   @linter.run(processed_source)
+  def test_does_not_warn_when_banned_text_is_part_of_more_text
+    @file = "<a>Learn more about GitHub Stars</a>"
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_ignores_when_aria_label_with_variable_is_set_on_link_tag
-  #   @file = <<~ERB
-  #     <a aria-label="<%= tooltip_text %>">Learn more</a>
-  #   ERB
-  #   @linter.run(processed_source)
+  def test_ignores_when_aria_label_with_variable_is_set_on_link_tag
+    @file = <<~ERB
+      <a aria-label="<%= tooltip_text %>">Learn more</a>
+    ERB
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_flags_when_aria_label_does_not_include_visible_link_text
-  #   @file = <<~ERB
-  #     <a aria-label="GitHub Sponsors">Learn more</a>
-  #   ERB
-  #   @linter.run(processed_source)
+  def test_flags_when_aria_label_does_not_include_visible_link_text
+    @file = <<~ERB
+      <a aria-label="GitHub Sponsors">Learn more</a>
+    ERB
+    @linter.run(processed_source)
 
-  #   refute_empty @linter.offenses
-  # end
+    refute_empty @linter.offenses
+  end
 
-  # def test_does_not_flag_when_aria_label_includes_visible_link_text
-  #   @file = <<~ERB
-  #     <a aria-label="Learn more about GitHub Sponsors">Learn more</a>
-  #   ERB
-  #   @linter.run(processed_source)
+  def test_does_not_flag_when_aria_label_includes_visible_link_text
+    @file = <<~ERB
+      <a aria-label="Learn more about GitHub Sponsors">Learn more</a>
+    ERB
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_ignores_when_aria_labelledby_is_set_on_link_tag
-  #   @file = "<a aria-labelledby='someElement'>Click here</a>"
-  #   @linter.run(processed_source)
+  def test_ignores_when_aria_labelledby_is_set_on_link_tag
+    @file = "<a aria-labelledby='someElement'>Click here</a>"
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_warns_when_link_rails_helper_text_is_banned_text
-  #   @file = "<%= link_to('click here', redirect_url, id: 'redirect') %>"
-  #   @linter.run(processed_source)
+  def test_warns_when_link_rails_helper_text_is_banned_text
+    @file = "<%= link_to('click here', redirect_url, id: 'redirect') %>"
+    @linter.run(processed_source)
 
-  #   refute_empty @linter.offenses
-  # end
+    refute_empty @linter.offenses
+  end
 
-  # def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_labelled_by
-  #   @file = "<%= link_to('learn more', 'aria-labelledby': 'element1234', id: 'redirect') %>"
-  #   @linter.run(processed_source)
+  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_labelled_by
+    @file = "<%= link_to('learn more', 'aria-labelledby': 'element1234', id: 'redirect') %>"
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_cannot_be_parsed_by_linter
-  #   @file = <<~ERB
-  #     <%= link_to('learn more', 'aria-label': some_variable, id: 'redirect') %>
-  #   ERB
-  #   @linter.run(processed_source)
+  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_cannot_be_parsed_by_linter
+    @file = <<~ERB
+      <%= link_to('learn more', 'aria-label': some_variable, id: 'redirect') %>
+    ERB
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_cannot_be_parsed_by_linter_because_interpolated
+  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_since_cannot_be_parsed_accurately_by_linter
     @file = <<~ERB
       <%= link_to('learn more', 'aria-label': "Learn #{@variable}", id: 'redirect') %>
     ERB
@@ -115,48 +115,48 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     assert_empty @linter.offenses
   end
 
-  # def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_contains_visible_text
-  #   @file = "<%= link_to('learn more', 'aria-label': 'learn more about GitHub', id: 'redirect') %>"
-  #   @linter.run(processed_source)
+  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label
+    @file = "<%= link_to('learn more', 'aria-label': 'learn more about GitHub', id: 'redirect') %>"
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_warns_when_link_rails_helper_text_is_banned_text_with_aria_label_hash
-  #   @file = "<%= link_to('learn more', aria: { label: 'learn more about GitHub' }, id: 'redirect') %>"
-  #   @linter.run(processed_source)
+  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_hash
+    @file = "<%= link_to('learn more', aria: { label: 'learn more about GitHub' }, id: 'redirect') %>"
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_does_not_warn_when_generic_text_is_link_rails_helper_sub_text
-  #   @file = "<%= link_to('click here to learn about github', redirect_url, id: 'redirect') %>"
-  #   @linter.run(processed_source)
+  def test_does_not_warn_when_generic_text_is_link_rails_helper_sub_text
+    @file = "<%= link_to('click here to learn about github', redirect_url, id: 'redirect') %>"
+    @linter.run(processed_source)
 
-  #   assert_empty @linter.offenses
-  # end
+    assert_empty @linter.offenses
+  end
 
-  # def test_does_not_warns_if_element_has_correct_counter_comment
-  #   @file = <<~ERB
-  #     <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
-  #     <a>Link</a>
-  #   ERB
-  #   @linter.run(processed_source)
+  def test_does_not_warns_if_element_has_correct_counter_comment
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
+      <a>Link</a>
+    ERB
+    @linter.run(processed_source)
 
-  #   assert_equal 0, @linter.offenses.count
-  # end
+    assert_equal 0, @linter.offenses.count
+  end
 
-  # def test_autocorrects_when_ignores_are_not_correct
-  #   @file = <<~ERB
-  #     <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 2 %>
-  #     <a>Link</a>
-  #   ERB
-  #   refute_equal @file, corrected_content
+  def test_autocorrects_when_ignores_are_not_correct
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 2 %>
+      <a>Link</a>
+    ERB
+    refute_equal @file, corrected_content
 
-  #   expected_content = <<~ERB
-  #     <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
-  #     <a>Link</a>
-  #   ERB
-  #   assert_equal expected_content, corrected_content
-  # end
+    expected_content = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
+      <a>Link</a>
+    ERB
+    assert_equal expected_content, corrected_content
+  end
 end

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -145,6 +145,24 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     assert_empty @linter.offenses
   end
 
+  def test_handles_files_with_various_links
+    @file = <<~ERB
+      <p>
+        <a aria-labelledby='someElement'>Click here</a>
+      </p>
+      <p>
+        <%= link_to "learn more", billing_path, "aria-label": "something" %>
+        <%= link_to "learn more", billing_path, aria: { label: "something" } %>
+        <%= link_to "learn more", billing_path, aria: { describedby: "element123" } %>
+        <%= link_to "learn more", billing_path, "aria-describedby": "element123" %>
+      </p>
+    ERB
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+    assert_equal 3, @linter.offenses.count
+  end
+
   def test_does_not_warns_if_element_has_correct_counter_comment
     @file = <<~ERB
       <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -178,14 +178,33 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
 
   def test_autocorrects_when_ignores_are_not_correct
     @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 2 %>
-      <a>Link</a>
+      <p>
+        <a href="github.com" aria-label='Click here to learn more'>Click here</a>
+        <a href="github.com" aria-label='Some totally different text'>Click here</a>
+        <a href="github.com" aria-labelledby='someElement'>Click here</a>
+      </p>
+      <p>
+        <%= link_to "learn more", billing_path, "aria-label": "something" %>
+        <%= link_to "learn more", billing_path, aria: { label: "something" } %>
+        <%= link_to "learn more", billing_path, aria: { describedby: "element123" } %>
+        <%= link_to "learn more", billing_path, "aria-describedby": "element123" %>
+      </p>
     ERB
     refute_equal @file, corrected_content
 
     expected_content = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
-      <a>Link</a>
+      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 3 %>
+      <p>
+        <a href="github.com" aria-label='Click here to learn more'>Click here</a>
+        <a href="github.com" aria-label='Some totally different text'>Click here</a>
+        <a href="github.com" aria-labelledby='someElement'>Click here</a>
+      </p>
+      <p>
+        <%= link_to "learn more", billing_path, "aria-label": "something" %>
+        <%= link_to "learn more", billing_path, aria: { label: "something" } %>
+        <%= link_to "learn more", billing_path, aria: { describedby: "element123" } %>
+        <%= link_to "learn more", billing_path, "aria-describedby": "element123" %>
+      </p>
     ERB
     assert_equal expected_content, corrected_content
   end

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -90,6 +90,15 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     refute_empty @linter.offenses
   end
 
+  def test_warns_when_link_rails_helper_text_is_banned_text_with_aria_description
+    @file = <<~ERB
+      <%= link_to('click here', 'aria-describedby': 'element123', id: 'redirect') %>
+    ERB
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
   def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_labelled_by
     @file = "<%= link_to('learn more', 'aria-labelledby': 'element1234', id: 'redirect') %>"
     @linter.run(processed_source)

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -84,7 +84,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
   end
 
   def test_warns_when_link_rails_helper_text_is_banned_text
-    @file = "<%= link_to('click here', redirect_url, id: 'redirect') %>"
+    @file = "<%= link_to('click here', redirect_url) %>"
     @linter.run(processed_source)
 
     refute_empty @linter.offenses
@@ -92,7 +92,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
 
   def test_warns_when_link_rails_helper_text_is_banned_text_with_aria_description
     @file = <<~ERB
-      <%= link_to('click here', 'aria-describedby': 'element123', id: 'redirect') %>
+      <%= link_to('click here', redirect_url, 'aria-describedby': 'element123', id: 'redirect') %>
     ERB
     @linter.run(processed_source)
 
@@ -100,7 +100,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
   end
 
   def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_labelled_by
-    @file = "<%= link_to('learn more', 'aria-labelledby': 'element1234', id: 'redirect') %>"
+    @file = "<%= link_to('learn more', redirect_url, 'aria-labelledby': 'element1234', id: 'redirect') %>"
     @linter.run(processed_source)
 
     assert_empty @linter.offenses
@@ -108,7 +108,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
 
   def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_cannot_be_parsed_by_linter
     @file = <<~ERB
-      <%= link_to('learn more', 'aria-label': some_variable, id: 'redirect') %>
+      <%= link_to('learn more', redirect_url, 'aria-label': some_variable, id: 'redirect') %>
     ERB
     @linter.run(processed_source)
 
@@ -117,7 +117,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
 
   def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_since_cannot_be_parsed_accurately_by_linter
     @file = <<~ERB
-      <%= link_to('learn more', 'aria-label': "Learn #{@variable}", id: 'redirect') %>
+      <%= link_to('learn more', redirect_url, 'aria-label': "Learn #{@variable}", id: 'redirect') %>
     ERB
     @linter.run(processed_source)
 
@@ -125,14 +125,14 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
   end
 
   def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label
-    @file = "<%= link_to('learn more', 'aria-label': 'learn more about GitHub', id: 'redirect') %>"
+    @file = "<%= link_to('learn more', redirect_url, 'aria-label': 'learn more about GitHub', id: 'redirect') %>"
     @linter.run(processed_source)
 
     assert_empty @linter.offenses
   end
 
   def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_hash
-    @file = "<%= link_to('learn more', aria: { label: 'learn more about GitHub' }, id: 'redirect') %>"
+    @file = "<%= link_to('learn more', redirect_url, aria: { label: 'learn more about GitHub' }, id: 'redirect') %>"
     @linter.run(processed_source)
 
     assert_empty @linter.offenses

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -7,83 +7,156 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     ERBLint::Linters::GitHub::Accessibility::AvoidGenericLinkTextCounter
   end
 
-  def test_warns_when_link_text_is_click_here
-    @file = "<a>Click here</a>"
-    @linter.run(processed_source)
+  # def test_warns_when_link_text_is_click_here
+  #   @file = "<a>Click here</a>"
+  #   @linter.run(processed_source)
 
-    refute_empty @linter.offenses
-  end
+  #   refute_empty @linter.offenses
+  # end
 
-  def test_warns_when_link_text_is_learn_more
-    @file = "<a>Learn more</a>"
-    @linter.run(processed_source)
+  # def test_warns_when_link_text_is_learn_more
+  #   @file = "<a>Learn more</a>"
+  #   @linter.run(processed_source)
 
-    refute_empty @linter.offenses
-  end
+  #   refute_empty @linter.offenses
+  # end
 
-  def test_warns_when_link_text_is_read_more
-    @file = "<a>Read more</a>"
-    @linter.run(processed_source)
+  # def test_warns_when_link_text_is_read_more
+  #   @file = "<a>Read more</a>"
+  #   @linter.run(processed_source)
 
-    refute_empty @linter.offenses
-  end
+  #   refute_empty @linter.offenses
+  # end
 
-  def test_warns_when_link_text_is_more
-    @file = "<a>More</a>"
-    @linter.run(processed_source)
+  # def test_warns_when_link_text_is_more
+  #   @file = "<a>More</a>"
+  #   @linter.run(processed_source)
 
-    refute_empty @linter.offenses
-  end
+  #   refute_empty @linter.offenses
+  # end
 
-  def test_warns_when_link_text_is_link
-    @file = "<a>Link</a>"
-    @linter.run(processed_source)
+  # def test_warns_when_link_text_is_link
+  #   @file = "<a>Link</a>"
+  #   @linter.run(processed_source)
 
-    refute_empty @linter.offenses
-  end
+  #   refute_empty @linter.offenses
+  # end
 
-  def test_does_not_warn_when_banned_text_is_part_of_more_text
-    @file = "<a>Learn more about GitHub Stars</a>"
+  # def test_does_not_warn_when_banned_text_is_part_of_more_text
+  #   @file = "<a>Learn more about GitHub Stars</a>"
+  #   @linter.run(processed_source)
+
+  #   assert_empty @linter.offenses
+  # end
+
+  # def test_ignores_when_aria_label_with_variable_is_set_on_link_tag
+  #   @file = <<~ERB
+  #     <a aria-label="<%= tooltip_text %>">Learn more</a>
+  #   ERB
+  #   @linter.run(processed_source)
+
+  #   assert_empty @linter.offenses
+  # end
+
+  # def test_flags_when_aria_label_does_not_include_visible_link_text
+  #   @file = <<~ERB
+  #     <a aria-label="GitHub Sponsors">Learn more</a>
+  #   ERB
+  #   @linter.run(processed_source)
+
+  #   refute_empty @linter.offenses
+  # end
+
+  # def test_does_not_flag_when_aria_label_includes_visible_link_text
+  #   @file = <<~ERB
+  #     <a aria-label="Learn more about GitHub Sponsors">Learn more</a>
+  #   ERB
+  #   @linter.run(processed_source)
+
+  #   assert_empty @linter.offenses
+  # end
+
+  # def test_ignores_when_aria_labelledby_is_set_on_link_tag
+  #   @file = "<a aria-labelledby='someElement'>Click here</a>"
+  #   @linter.run(processed_source)
+
+  #   assert_empty @linter.offenses
+  # end
+
+  # def test_warns_when_link_rails_helper_text_is_banned_text
+  #   @file = "<%= link_to('click here', redirect_url, id: 'redirect') %>"
+  #   @linter.run(processed_source)
+
+  #   refute_empty @linter.offenses
+  # end
+
+  # def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_labelled_by
+  #   @file = "<%= link_to('learn more', 'aria-labelledby': 'element1234', id: 'redirect') %>"
+  #   @linter.run(processed_source)
+
+  #   assert_empty @linter.offenses
+  # end
+
+  # def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_cannot_be_parsed_by_linter
+  #   @file = <<~ERB
+  #     <%= link_to('learn more', 'aria-label': some_variable, id: 'redirect') %>
+  #   ERB
+  #   @linter.run(processed_source)
+
+  #   assert_empty @linter.offenses
+  # end
+
+  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_cannot_be_parsed_by_linter_because_interpolated
+    @file = <<~ERB
+      <%= link_to('learn more', 'aria-label': "Learn #{@variable}", id: 'redirect') %>
+    ERB
     @linter.run(processed_source)
 
     assert_empty @linter.offenses
   end
 
-  def test_warns_when_link_rails_helper_text_is_banned_text
-    @file = "<%= link_to('click here', redirect_url, id: 'redirect') %>"
-    @linter.run(processed_source)
+  # def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_contains_visible_text
+  #   @file = "<%= link_to('learn more', 'aria-label': 'learn more about GitHub', id: 'redirect') %>"
+  #   @linter.run(processed_source)
 
-    refute_empty @linter.offenses
-  end
+  #   assert_empty @linter.offenses
+  # end
 
-  def test_does_not_warn_when_generic_text_is_link_rails_helper_sub_text
-    @file = "<%= link_to('click here to learn about github', redirect_url, id: 'redirect') %>"
-    @linter.run(processed_source)
+  # def test_warns_when_link_rails_helper_text_is_banned_text_with_aria_label_hash
+  #   @file = "<%= link_to('learn more', aria: { label: 'learn more about GitHub' }, id: 'redirect') %>"
+  #   @linter.run(processed_source)
 
-    assert_empty @linter.offenses
-  end
+  #   assert_empty @linter.offenses
+  # end
 
-  def test_does_not_warns_if_element_has_correct_counter_comment
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
-      <a>Link</a>
-    ERB
-    @linter.run(processed_source)
+  # def test_does_not_warn_when_generic_text_is_link_rails_helper_sub_text
+  #   @file = "<%= link_to('click here to learn about github', redirect_url, id: 'redirect') %>"
+  #   @linter.run(processed_source)
 
-    assert_equal 0, @linter.offenses.count
-  end
+  #   assert_empty @linter.offenses
+  # end
 
-  def test_autocorrects_when_ignores_are_not_correct
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 2 %>
-      <a>Link</a>
-    ERB
-    refute_equal @file, corrected_content
+  # def test_does_not_warns_if_element_has_correct_counter_comment
+  #   @file = <<~ERB
+  #     <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
+  #     <a>Link</a>
+  #   ERB
+  #   @linter.run(processed_source)
 
-    expected_content = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
-      <a>Link</a>
-    ERB
-    assert_equal expected_content, corrected_content
-  end
+  #   assert_equal 0, @linter.offenses.count
+  # end
+
+  # def test_autocorrects_when_ignores_are_not_correct
+  #   @file = <<~ERB
+  #     <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 2 %>
+  #     <a>Link</a>
+  #   ERB
+  #   refute_equal @file, corrected_content
+
+  #   expected_content = <<~ERB
+  #     <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
+  #     <a>Link</a>
+  #   ERB
+  #   assert_equal expected_content, corrected_content
+  # end
 end

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -76,7 +76,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     assert_empty @linter.offenses
   end
 
-  def test_ignores_when_aria_labelledby_is_set_on_link_tag
+  def test_ignores_when_aria_labelledby_is_set_on_link_tag_since_cannot_be_evaluated_accurately_by_erb_linter
     @file = "<a aria-labelledby='someElement'>Click here</a>"
     @linter.run(processed_source)
 
@@ -99,47 +99,14 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     refute_empty @linter.offenses
   end
 
-  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_labelled_by
-    @file = "<%= link_to('learn more', redirect_url, 'aria-labelledby': 'element1234', id: 'redirect') %>"
-    @linter.run(processed_source)
-
-    assert_empty @linter.offenses
-  end
-
-  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_that_cannot_be_parsed_by_linter
+  def test_ignores_when_link_rails_helper_text_is_banned_text_with_any_aria_label_attributes_since_cannot_be_evaluated_accurately_by_erb_linter
     @file = <<~ERB
+      <%= link_to('learn more', redirect_url, 'aria-labelledby': 'element1234', id: 'redirect') %>
       <%= link_to('learn more', redirect_url, 'aria-label': some_variable, id: 'redirect') %>
-    ERB
-    @linter.run(processed_source)
-
-    assert_empty @linter.offenses
-  end
-
-  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_since_cannot_be_parsed_accurately_by_linter
-    @file = <<~ERB
       <%= link_to('learn more', redirect_url, 'aria-label': "Learn #{@variable}", id: 'redirect') %>
+      <%= link_to('learn more', redirect_url, 'aria-label': 'learn more about GitHub', id: 'redirect') %>
+      <%= link_to('learn more', redirect_url, aria: { label: 'learn more about GitHub' }, id: 'redirect') %>
     ERB
-    @linter.run(processed_source)
-
-    assert_empty @linter.offenses
-  end
-
-  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label
-    @file = "<%= link_to('learn more', redirect_url, 'aria-label': 'learn more about GitHub', id: 'redirect') %>"
-    @linter.run(processed_source)
-
-    assert_empty @linter.offenses
-  end
-
-  def test_ignores_when_link_rails_helper_text_is_banned_text_with_aria_label_hash
-    @file = "<%= link_to('learn more', redirect_url, aria: { label: 'learn more about GitHub' }, id: 'redirect') %>"
-    @linter.run(processed_source)
-
-    assert_empty @linter.offenses
-  end
-
-  def test_does_not_warn_when_generic_text_is_link_rails_helper_sub_text
-    @file = "<%= link_to('click here to learn about github', redirect_url, id: 'redirect') %>"
     @linter.run(processed_source)
 
     assert_empty @linter.offenses
@@ -149,11 +116,11 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     @file = <<~ERB
       <p>
         <a href="github.com" aria-label='Click here to learn more'>Click here</a>
+        <%= link_to "learn more", billing_path, "aria-label": "something" %>
         <a href="github.com" aria-label='Some totally different text'>Click here</a>
         <a href="github.com" aria-labelledby='someElement'>Click here</a>
       </p>
       <p>
-        <%= link_to "learn more", billing_path, "aria-label": "something" %>
         <%= link_to "learn more", billing_path, aria: { label: "something" } %>
         <%= link_to "learn more", billing_path, aria: { describedby: "element123" } %>
         <%= link_to "learn more", billing_path, "aria-describedby": "element123" %>


### PR DESCRIPTION
Relates to: https://github.com/github/accessibility/issues/1291

@github/accessibility-reviewers before you review, please check the discussion in the linked issue :) 

## Changes
This refines the generic linter text introduced in https://github.com/github/erblint-github/pull/32 based on internal discussions.

Currently, this linter will flag a link with generic text even if it has a descriptive accessible name set by `aria-labelledby` or `aria-label`. This is a _sometimes_ acceptable technique even if it may not be the most preferable, so we don't want to raise a flag because it could be a false positive. 

This updates the linter to not evaluate links with generic text that have ARIA attributes since linters should never raise false positives. One nuance we discussed is that when using ARIA to set a more descriptive accessible name, one _must_ ensure that the visible text is contained in the accessible name output. This is because this would be a violation of [Success Criterion 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name). 

If the linter is able to access the `aria-label` string and _can accurately_ determine that the `aria-label` text does not contain the visible text at all, it **will** raise a flag. Notably, because this is static code analysis, we have limitations when it comes to evaluating the actual runtime values of the accessible name output, so this flag won't always be raised.

### Examples of accessible name that ERB lint can and cannot evaluate

ERB lint can evaluate the accessible name when `aria-label` is a string:
```
<a href="github.com" aria-label='Learn more about GitHub'>Learn more</a>

```

ERB lint cannot evaluate the accessible name when `aria-labelledby` so we skip:
```
<a href="github.com" aria-labelledby='element123'>Learn more</a>

```

ERB lint cannot evaluate the accessible name since it's a variable so we skip:
```
<a href="github.com" aria-label="<%= some_variable %>">Learn more</a>

```

ERB lint cannot accurately evaluate the accessible name of `link_to` helpers with `aria-label` or `aria-labelledby` attributes so we skip completely:
```
<%= link_to "learn more", billing_path, "aria-label": "learn #{@some_variable}" %>
# The aria-label output by ERB is simply `learn` which is inaccurate
```
Even with these limitations around not being able to comprehensively evaluate links if they have ARIA label attributes set, this linter should catch quite a number of issues.

I've added a note in the doc that further informs these changes. The code is a bit complex so I added comments and additional tests which should help. 

## References
GitHub Staff only - [Discussion on nuanced uses of ARIA to provide more descriptive text](https://github.com/github/accessibility/issues/1291#issuecomment-1159088348)