### PR TITLE
Make linter not count punctuation against match

### DIFF
--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -113,7 +113,7 @@ module ERBLint
           private
 
           def banned_text?(text)
-            BANNED_GENERIC_TEXT.map(&:downcase).include?(text.downcase.gsub(/\W+/, ' ').strip)
+            BANNED_GENERIC_TEXT.map(&:downcase).include?(text.downcase.gsub(/\W+/, " ").strip)
           end
 
           def valid_accessible_name?(aria_label, text)

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -113,7 +113,7 @@ module ERBLint
           private
 
           def banned_text?(text)
-            BANNED_GENERIC_TEXT.map(&:downcase).include?(text.downcase)
+            BANNED_GENERIC_TEXT.map(&:downcase).include?(text.downcase.gsub(/\W+/, ' ').strip)
           end
 
           def valid_accessible_name?(aria_label, text)

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -42,6 +42,19 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
     refute_empty @linter.offenses
   end
 
+  def test_warns_when_link_text_is_banned_text_with_punctuation_and_space
+    @file = <<~ERB
+      <a>Learn more!</a>
+      <a>   read more.</a>
+      <a>click  here.</a>
+    ERB
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+    # 3 offenses, 1 related to matching counter comment not present despite violations
+    assert_equal 4, @linter.offenses.count
+  end
+
   def test_does_not_warn_when_banned_text_is_part_of_more_text
     @file = "<a>Learn more about GitHub Stars</a>"
     @linter.run(processed_source)


### PR DESCRIPTION
I noticed a PR in dotcom with the text, `Learn more.` which this linter didn't catch because it only looks for case-insensitive exact string match.

This PR updates the linter to ignore punctuations and multiple whitespaces so we flag:

- `Learn more.`
- `Click     here!!! `