### PR TITLE
bug: Fixes AvoidGenericLinkText bug

### DIFF
--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -112,12 +112,17 @@ module ERBLint
 
           private
 
+          # Downcase and strip punctuation and extra whitespaces.
+          def stripped_text(text)
+            text.downcase.gsub(/\W+/, " ").strip
+          end
+
           def banned_text?(text)
-            BANNED_GENERIC_TEXT.map(&:downcase).include?(text.downcase.gsub(/\W+/, " ").strip)
+            BANNED_GENERIC_TEXT.map(&:downcase).include?(stripped_text(text))
           end
 
           def valid_accessible_name?(aria_label, text)
-            aria_label.downcase.include?(text.downcase)
+            stripped_text(aria_label).include?(stripped_text(text))
           end
 
           def extract_ruby_node(source)

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -122,7 +122,7 @@ module ERBLint
           end
 
           def valid_accessible_name?(aria_label, text)
-            stripped_text(aria_label).include?(stripped_text(text))
+            aria_label.downcase.include?(stripped_text(text))
           end
 
           def extract_ruby_node(source)

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text_counter.rb
@@ -122,7 +122,7 @@ module ERBLint
           end
 
           def valid_accessible_name?(aria_label, text)
-            aria_label.downcase.include?(stripped_text(text))
+            stripped_text(aria_label).include?(stripped_text(text))
           end
 
           def extract_ruby_node(source)

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -82,7 +82,16 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
 
   def test_does_not_flag_when_aria_label_includes_visible_link_text
     @file = <<~ERB
-      <a aria-label="Learn more about GitHub Sponsors">Learn more</a>
+      <a aria-label="Learn more about GitHub Sponsors">Learn more.</a>
+    ERB
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+
+  def test_does_not_flag_when_aria_label_includes_visible_link_text_insensitive_case_and_puncutation
+    @file = <<~ERB
+      <a aria-label="Learn more about GitHub Sponsors">LEARN MORE!</a>
     ERB
     @linter.run(processed_source)
 

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -82,16 +82,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
 
   def test_does_not_flag_when_aria_label_includes_visible_link_text
     @file = <<~ERB
-      <a aria-label="Learn more about GitHub Sponsors">Learn more.</a>
-    ERB
-    @linter.run(processed_source)
-
-    assert_empty @linter.offenses
-  end
-
-  def test_does_not_flag_when_aria_label_includes_visible_link_text_insensitive_case_and_puncutation
-    @file = <<~ERB
-      <a aria-label="Learn more about GitHub Sponsors">LEARN MORE!</a>
+      <a aria-label="Learn more about GitHub Sponsors.">Learn more.</a>
     ERB
     @linter.run(processed_source)
 

--- a/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_counter_test.rb
@@ -83,6 +83,7 @@ class AvoidGenericLinkTextCounterTest < LinterTestCase
   def test_does_not_flag_when_aria_label_includes_visible_link_text
     @file = <<~ERB
       <a aria-label="Learn more about GitHub Sponsors.">Learn more.</a>
+      <a aria-label="Learn more about GitHub Sponsors.">Learn more  </a>
     ERB
     @linter.run(processed_source)
 


### PR DESCRIPTION
This PR fixes a bug where the punctuation of the visible text makes the `valid_accessible_name` check fail.

Example:

```
<a aria-label="Learn more about GitHub Sponsors.">Learn more.</a>
```

We have a check to make sure that the visible label is fully included inside of the accessible name text. Currently, we straight up take the visible text and see if it's included inside of the aria label. However, we don't strip the punctuation from the visible text before we do the check causing this example to incorrectly fail.

This PR makes it so we strip whitespace and punctuation from the visible label.

Thanks @jschnapper for pointing this out!

([Related Slack Context (GitHub Staff only)](https://github.slack.com/archives/C0FSWLQ0Y/p1657574649247259))