### PR TITLE
Migrate accessibility rule `a11y_disabled_attribute` from dotcom to erblint-github

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ linters:
     enabled: true
   GitHub::Accessibility::AvoidGenericLinkTextCounter:
     enabled: true
+  GitHub::Accessibility::DisabledAttributeCounter:
+    enabled: true
   GitHub::Accessibility::IframeHasTitle:
     enabled: true
   GitHub::Accessibility::ImageHasAlt:
@@ -45,6 +47,7 @@ linters:
 
 - [GitHub::Accessibility::AvoidBothDisabledAndAriaDisabled](./docs/rules/accessibility/avoid-both-disabled-and-aria-disabled.md)
 - [GitHub::Accessibility::AvoidGenericLinkTextCounter](./docs/rules/accessibility/avoid-generic-link-text-counter.md)
+- [GitHub::Accessibility::DisabledAttributeCounter](./docs/rules/accessibility/disabled-attribute-counter-test)
 - [GitHub::Accessibility::IframeHasTitle](./docs/rules/accessibility/iframe-has-title.md)
 - [GitHub::Accessibility::ImageHasAlt](./docs/rules/accessibility/image-has-alt.md)
 - [GitHub::Accessibility::NoAriaLabelMisuseCounter](./docs/rules/accessibility/no-aria-label-misuse-counter.md)

--- a/docs/rules/accessibility/disabled-attribute-counter.md
+++ b/docs/rules/accessibility/disabled-attribute-counter.md
@@ -1,0 +1,24 @@
+# Disabled attribute counter
+
+## Rule Details
+
+The attribute `disabled` is only valid on the following elements: button, input, textarea, option, select, fieldset, optgroup, task-lists.
+
+## Resources
+
+- [HTML attribute: `disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled)
+
+## Examples
+### **Incorrect** code for this rule 👎
+
+```erb
+<!-- incorrect -->
+<a href='https://github.com/' disabled>Go to GitHub</a>
+```
+
+### **Correct** code for this rule  👍
+
+```erb
+<!-- correct -->
+<button disabled>Continue</button>
+```

--- a/lib/erblint-github/linters/github/accessibility/disabled_attribute_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/disabled_attribute_counter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "../../custom_helpers"
+
+module ERBLint
+  module Linters
+    module GitHub
+      module Accessibility
+        class DisabledAttributeCounter < Linter
+          include ERBLint::Linters::CustomHelpers
+          include LinterRegistry
+
+          VALID_DISABLED_TAGS = %w[button input textarea option select fieldset optgroup task-lists].freeze
+          MESSAGE = "`disabled` is only valid on #{VALID_DISABLED_TAGS.join(', ')}."
+
+          def run(processed_source)
+            tags(processed_source).each do |tag|
+              next if tag.closing?
+              next if VALID_DISABLED_TAGS.include?(tag.name)
+              next if tag.attributes["disabled"].nil?
+
+              generate_offense(self.class, processed_source, tag)
+            end
+
+            counter_correct?(processed_source)
+          end
+
+          def autocorrect(processed_source, offense)
+            return unless offense.context
+
+            lambda do |corrector|
+              if processed_source.file_content.include?("erblint:counter #{simple_class_name}")
+                # update the counter if exists
+                corrector.replace(offense.source_range, offense.context)
+              else
+                # add comment with counter if none
+                corrector.insert_before(processed_source.source_buffer.source_range, "#{offense.context}\n")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/linters/accessibility/disabled_attribute_counter_test.rb
+++ b/test/linters/accessibility/disabled_attribute_counter_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DisabledAttributeCounter < LinterTestCase
+  def linter_class
+    ERBLint::Linters::GitHub::Accessibility::DisabledAttributeCounter
+  end
+
+  def test_warns_if_invalid_element_has_disabled_attribute
+    @file = "<a href='https://github.com/' disabled>Go to GitHub</a>"
+    @linter.run(processed_source)
+
+    assert_equal(2, @linter.offenses.count)
+    error_messages = @linter.offenses.map(&:message).sort
+    assert_match(/If you must, add <%# erblint:counter GitHub::Accessibility::DisabledAttributeCounter 1 %> to bypass this check./, error_messages.first)
+    assert_match(/`disabled` is only valid on button, input, textarea, option, select, fieldset, optgroup, task-lists./, error_messages.last)
+  end
+
+  def test_does_not_warn_if_valid_element_has_disabled_attribute
+    @file = "<button disabled>Continue</button>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+
+  def test_does_not_warn_if_link_has_href_attribute_and_has_correct_counter_comment
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::DisabledAttributeCounter 1 %>
+      <a href='https://github.com/' disabled>Go to GitHub</a>
+    ERB
+    @linter.run(processed_source)
+
+    assert_equal 0, @linter.offenses.count
+  end
+
+  def test_does_not_autocorrect_when_ignores_are_correct
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::DisabledAttributeCounter 1 %>
+      <a href='https://github.com/' disabled>Go to GitHub</a>
+    ERB
+
+    assert_equal @file, corrected_content
+  end
+
+  def test_does_autocorrect_when_ignores_are_not_correct
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::DisabledAttributeCounter 3 %>
+      <a href='https://github.com/' disabled>Go to GitHub</a>
+    ERB
+    refute_equal @file, corrected_content
+
+    expected_content = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::DisabledAttributeCounter 1 %>
+      <a href='https://github.com/' disabled>Go to GitHub</a>
+    ERB
+    assert_equal expected_content, corrected_content
+  end
+end


### PR DESCRIPTION
## Context

The motivation of [erblint-github](https://github.com/github/erblint-github) is to open-source our accessibility rules so non-GitHub people can benefit from them, have a space to provide comprehensive rule documentation, and also allow rules to be shared between Rails projects.

This PR migrates the accessibility rule `a11y_disabled_attribute` from dotcom to erblint-github

### Related issue

- https://github.com/github/accessibility/issues/1293