### PR TITLE
Migrate accessibility rule `a11y_svg_has_accessible_text` from dotcom to erblint-github

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ linters:
     enabled: true
   GitHub::Accessibility::NoTitleAttributeCounter:
     enabled: true
+  GitHub::Accessibility::SvgHasAccessibleTextCounter:
+    enabled: true
 ```
 
 ## Rules
@@ -51,6 +53,7 @@ linters:
 - [GitHub::Accessibility::NoPositiveTabIndex](./docs/rules/accessibility/no-positive-tab-index.md)
 - [GitHub::Accessibility::NoRedundantImageAlt](./docs/rules/accessibility/no-redundant-image-alt.md)
 - [GitHub::Accessibility::NoTitleAttributeCounter](./docs/rules/accessibility/no-title-attribute-counter.md)
+- [GitHub::Accessibility::SvgHasAccessibleTextCounter](./docs/rules/accessibility/svg_has_accessible_text_counter.md)
 
 ## Testing
 

--- a/docs/rules/accessibility/svg-has-accessible-text-counter.md
+++ b/docs/rules/accessibility/svg-has-accessible-text-counter.md
@@ -1,0 +1,40 @@
+# SVG has accessible text counter
+
+## Rule Details
+
+`<svg>` must have accessible text. Set `aria-label`, or `aria-labelledby`, or nest a `<title>` element.
+However, if the `<svg>` is purely decorative, hide it with `aria-hidden='true'.
+
+## Resources
+
+- [Accessible SVGs](https://css-tricks.com/accessible-svgs/)
+
+## Examples
+### **Incorrect** code for this rule 👎
+
+```erb
+<!-- incorrect -->
+<svg height='100' width='100'>
+  <circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/>
+</svg>
+```
+
+### **Correct** code for this rule  👍
+
+```erb
+<!-- correct -->
+<svg aria-label='A circle' height='100' width='100'>
+  <circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/>
+</svg>
+
+<!-- correct -->
+<svg aria-labelledby='test_id' height='100' width='100'>
+  <circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/>
+</svg>
+
+<!-- correct -->
+<svg height='100' width='100'>
+  <title>A circle</title>
+  <circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/>
+</svg>
+```

--- a/lib/erblint-github/linters/github/accessibility/svg_has_accessible_text_counter.rb
+++ b/lib/erblint-github/linters/github/accessibility/svg_has_accessible_text_counter.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "../../custom_helpers"
+
+module ERBLint
+  module Linters
+    module GitHub
+      module Accessibility
+        class SvgHasAccessibleTextCounter < Linter
+          include ERBLint::Linters::CustomHelpers
+          include LinterRegistry
+
+          MESSAGE = "`<svg>` must have accessible text. Set `aria-label`, or `aria-labelledby`, or nest a `<title>` element. However, if the `<svg>` is purely decorative, hide it with `aria-hidden='true'.\nFor more info, see https://css-tricks.com/accessible-svgs/."
+
+          def run(processed_source)
+            current_svg = nil
+            has_accessible_label = false
+
+            tags(processed_source).each do |tag|
+              # Checks whether tag is a <title> nested in an <svg>
+              has_accessible_label = true if current_svg && tag.name == "title" && !tag.closing?
+
+              next if tag.name != "svg"
+
+              if tag.closing?
+                generate_offense(self.class, processed_source, current_svg) unless has_accessible_label
+                current_svg = nil
+              elsif possible_attribute_values(tag, "aria-hidden").join == "true"
+                has_accessible_label = true
+                current_svg = tag
+              else
+                current_svg = tag
+                aria_label = possible_attribute_values(tag, "aria-label").join
+                aria_labelledby = possible_attribute_values(tag, "aria-labelledby").join
+
+                has_accessible_label = aria_label.present? || aria_labelledby.present?
+              end
+            end
+
+            counter_correct?(processed_source)
+          end
+
+          def autocorrect(processed_source, offense)
+            return unless offense.context
+
+            lambda do |corrector|
+              if processed_source.file_content.include?("erblint:counter #{simple_class_name}")
+                # update the counter if exists
+                corrector.replace(offense.source_range, offense.context)
+              else
+                # add comment with counter if none
+                corrector.insert_before(processed_source.source_buffer.source_range, "#{offense.context}\n")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/linters/accessibility/svg_has_accessible_text_counter_test.rb
+++ b/test/linters/accessibility/svg_has_accessible_text_counter_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SvgHasAccessibleTextCounter < LinterTestCase
+  def linter_class
+    ERBLint::Linters::GitHub::Accessibility::SvgHasAccessibleTextCounter
+  end
+
+  def test_warns_if_svg_does_not_have_accesible_text
+    @file = "<svg height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>"
+    @linter.run(processed_source)
+    assert_equal(2, @linter.offenses.count)
+    error_messages = @linter.offenses.map(&:message).sort
+    assert_match(/If you must, add <%# erblint:counter GitHub::Accessibility::SvgHasAccessibleTextCounter 1 %> to bypass this check./, error_messages.first)
+    assert_match(/`<svg>` must have accessible text. Set `aria-label`, or `aria-labelledby`, or nest a `<title>` element. However, if the `<svg>` is purely decorative, hide it with `aria-hidden='true'./, error_messages.last)
+  end
+
+  def test_does_not_warn_if_svg_has_accesible_text
+    @file = "<svg aria-label='A circle' height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+
+    @file = "<svg aria-labelledby='test_id' height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+
+    @file = "<svg height='100' width='100'><title>A circle</title><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+
+  def test_does_not_warn_if_svg_has_accesible_text_and_has_correct_counter_comment
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::SvgHasAccessibleTextCounter 1 %>
+      <svg height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>
+    ERB
+    @linter.run(processed_source)
+
+    assert_equal 0, @linter.offenses.count
+  end
+
+  def test_does_not_autocorrect_when_ignores_are_correct
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::SvgHasAccessibleTextCounter 1 %>
+      <svg height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>
+    ERB
+
+    assert_equal @file, corrected_content
+  end
+
+  def test_does_autocorrect_when_ignores_are_not_correct
+    @file = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::SvgHasAccessibleTextCounter 3 %>
+      <svg height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>
+    ERB
+    refute_equal @file, corrected_content
+
+    expected_content = <<~ERB
+      <%# erblint:counter GitHub::Accessibility::SvgHasAccessibleTextCounter 1 %>
+      <svg height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>
+    ERB
+    assert_equal expected_content, corrected_content
+  end
+end


### PR DESCRIPTION
## Context

The motivation of [erblint-github](https://github.com/github/erblint-github) is to open-source our accessibility rules so non-GitHub people can benefit from them, have a space to provide comprehensive rule documentation, and also allow rules to be shared between Rails projects.

This PR migrates the accessibility rule `a11y_svg_has_accessible_text` from dotcom to erblint-github

### Related issue

- https://github.com/github/accessibility/issues/1293