### PR TITLE
Update erblint-github gem to version `v0.1.1`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erblint-github (0.1.0)
+    erblint-github (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/erblint-github.gemspec
+++ b/erblint-github.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "erblint-github"
-  s.version = "0.1.0"
+  s.version = "0.1.1"
   s.summary = "erblint GitHub"
   s.description = "Template style checking for GitHub Ruby repositories"
   s.homepage = "https://github.com/github/erblint-github"


### PR DESCRIPTION
## Context

The motivation of [erblint-github](https://github.com/github/erblint-github) is to open-source our accessibility rules so non-GitHub people can benefit from them, have a space to provide comprehensive rule documentation, and also allow rules to be shared between Rails projects.

This PR updates the `erblint-github` gem version to `0.1.1` from `0.1.0`

### Related issue

- https://github.com/github/accessibility/issues/1293