### PR TITLE
Suggest adding native disable instead of counter

### DIFF
--- a/lib/erblint-github/linters/custom_helpers.rb
+++ b/lib/erblint-github/linters/custom_helpers.rb
@@ -8,24 +8,6 @@ module ERBLint
     module CustomHelpers
       INTERACTIVE_ELEMENTS = %w[button summary input select textarea a].freeze
 
-      def rule_disabled?(processed_source)
-        processed_source.parser.ast.descendants(:erb).each do |node|
-          indicator_node, _, code_node, = *node
-          indicator = indicator_node&.loc&.source
-          comment = code_node&.loc&.source&.strip
-          rule_name = simple_class_name
-
-          if indicator == "#" && comment.start_with?("erblint:disable") && comment.match(rule_name)
-            if @offenses.any?
-              clear_offenses
-            else
-              add_offense(processed_source.to_source_range(code_node.loc),
-                          "Unused erblint:disable comment for #{rule_name}")
-            end
-          end
-        end
-      end
-
       def counter_correct?(processed_source)
         comment_node = nil
         expected_count = 0

--- a/lib/erblint-github/linters/custom_helpers.rb
+++ b/lib/erblint-github/linters/custom_helpers.rb
@@ -34,10 +34,10 @@ module ERBLint
         first_offense = @offenses[0]
 
         if comment_node.nil?
-          add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:counter #{rule_name} #{offenses_count} %> to bypass this check.", "<%# erblint:counter #{rule_name} #{offenses_count} %>")
+          add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:disable #{rule_name} %> at the end of the offending line to bypass this check. See https://github.com/shopify/erb-lint#disable-rule-at-offense-level", "<%# erblint:disable #{rule_name} %>")
         else
           clear_offenses
-          add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", "<%# erblint:counter #{rule_name} #{offenses_count} %>") if expected_count != offenses_count
+          add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", "<%# erblint:counter #{rule_name}Counter #{offenses_count} %>") if expected_count != offenses_count
         end
       end
 

--- a/test/custom_helpers_test.rb
+++ b/test/custom_helpers_test.rb
@@ -20,27 +20,6 @@ class CustomHelpersTest < LinterTestCase
     @linter.extend(ERBLint::Linters::CustomHelpers)
   end
 
-  def test_rule_disabled_clears_offenses_if_rule_is_disabled
-    @file = <<~HTML
-      <%# erblint:disable CustomHelpersTest::FakeLinter %>
-    HTML
-    @linter.offenses = ["fake offense"]
-    assert_equal @linter.offenses.length, 1
-
-    extended_linter.rule_disabled?(processed_source)
-    assert_empty @linter.offenses
-  end
-
-  def test_rule_disabled_adds_offense_if_disable_comment_is_present_but_no_offense
-    @file = <<~HTML
-      <%# erblint:disable CustomHelpersTest::FakeLinter %>
-    HTML
-    assert_empty @linter.offenses
-
-    extended_linter.rule_disabled?(processed_source)
-    assert_equal "Unused erblint:disable comment for CustomHelpersTest::FakeLinter", @linter.offenses.first.message
-  end
-
   def test_counter_correct_does_not_add_offense_if_counter_matches_offense_count
     @file = <<~HTML
       <%# erblint:counter CustomHelpersTest::FakeLinter 1 %>

--- a/test/linters/accessibility/avoid_both_disabled_and_aria_disabled_test.rb
+++ b/test/linters/accessibility/avoid_both_disabled_and_aria_disabled_test.rb
@@ -44,7 +44,7 @@ class AvoidBothDisabledAndAriaDisabledTest < LinterTestCase
     @linter.run(processed_source)
 
     assert_equal @linter.offenses.count, 8
-    assert_match(/If you must, add <%# erblint:counter GitHub::Accessibility::AvoidBothDisabledAndAriaDisabled 7 %> to bypass this check/, @linter.offenses.last.message)
+    assert_match(/If you must, add <%# erblint:disable GitHub::Accessibility::AvoidBothDisabledAndAriaDisabled %> at the end of the offending line to bypass this check./, @linter.offenses.last.message)
   end
 
   def test_does_not_raise_when_ignore_comment_with_correct_count_if_counter_enabled


### PR DESCRIPTION
When the counter config is enabled, if there is no existing counter comment, let's suggest using `erblint:disable` and link to the docs to add inline disable natively, rather than suggesting adding a counter comment which is facing deprecation, now that we got inline disable support natively into `erblint`.

This PR additionally cleans up an unused method.