### PR TITLE
Update `AriaLabelIsWellFormatted` logic

### DIFF
--- a/lib/erblint-github/linters/custom_helpers.rb
+++ b/lib/erblint-github/linters/custom_helpers.rb
@@ -57,7 +57,7 @@ module ERBLint
 
       def possible_attribute_values(tag, attr_name)
         value = tag.attributes[attr_name]&.value || nil
-        basic_conditional_code_check(value || "") || [value].compact
+        [value].compact
       end
 
       # Map possible values from condition

--- a/lib/erblint-github/linters/github/accessibility/aria_label_is_well_formatted.rb
+++ b/lib/erblint-github/linters/github/accessibility/aria_label_is_well_formatted.rb
@@ -10,7 +10,7 @@ module ERBLint
           include ERBLint::Linters::CustomHelpers
           include LinterRegistry
 
-          MESSAGE = "[aria-label] text should be formatted the same as you would visual text. Use sentence case."
+          MESSAGE = "[aria-label] text should be formatted the same as you would visual text. Use sentence case, and don't format it like an ID. Additionally, `aria-label` should be concise and should not contain line breaks."
 
           class ConfigSchema < LinterConfig
             property :exceptions, accepts: array_of?(String),
@@ -23,9 +23,8 @@ module ERBLint
               next if tag.closing?
 
               aria_label = possible_attribute_values(tag, "aria-label").join
-              next if aria_label.empty?
 
-              if aria_label.match?(/^[a-z]/) && !@config.exceptions.include?(aria_label)
+              if (aria_label.start_with?(/^[a-z]/) || aria_label.match?(/[\r\n]+/)) && !@config.exceptions.include?(aria_label)
                 generate_offense(self.class, processed_source, tag)
               end
             end

--- a/test/linters/accessibility/aria_label_is_well_formatted_test.rb
+++ b/test/linters/accessibility/aria_label_is_well_formatted_test.rb
@@ -20,8 +20,24 @@ class AriaLabelIsWellFormatted < LinterTestCase
     assert_equal 5, @linter.offenses.count
   end
 
+  def test_warns_when_aria_label_contains_newline_characer
+    @file = <<~HTML
+      <button aria-label="Go to my&#10;website." ></button>
+      <button aria-label="Go to my\nwebsite." ></button>
+    HTML
+    @linter.run(processed_source)
+    assert_equal 2, @linter.offenses.count
+  end
+
   def test_does_not_warn_when_aria_labelledby_starts_with_downcase
     @file = "<button aria-labelledby='some-element-1'</button>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+
+  def test_does_not_warn_with_string_interpolation
+    @file = '<button aria-label="Add a cat <%= "or dog " if dog_allowed? %>pet"></button>'
     @linter.run(processed_source)
 
     assert_empty @linter.offenses
@@ -38,26 +54,14 @@ class AriaLabelIsWellFormatted < LinterTestCase
     assert_empty @linter.offenses
   end
 
-  def test_does_not_warn_when_aria_label_is_excepted_in_config
-    @file = <<~HTML
-     <button aria-label="Submit" ></button>
-     <button aria-label="Close" ></button>
-     <button aria-label="11 open" ></button>
-    HTML
-    @linter.run(processed_source)
-
-    assert_empty @linter.offenses
-  end
-
-
   def test_does_not_warn_if_aria_label_is_in_excepted_list
     @file = <<~HTML
      <button aria-label="hello" ></button>
-     <button aria-label="hello world" ></button>
+     <button aria-label="git checkout <%= some_branch %>"></button>
     HTML
-    @linter.config.exceptions = ["hello"]
+    @linter.config.exceptions = ["hello", "git checkout <%= some_branch %>"]
     @linter.run(processed_source)
 
-    assert_equal 1, @linter.offenses.count
+    assert_empty @linter.offenses
   end
 end


### PR DESCRIPTION
When I was working on the update in our app (staff-only: https://github.com/github/github/pull/269682), I noticed there were some scenarios that were being flagged that shouldn't be.

I am updating the logic of `AriaLabelIsWellFormatted` to make sure it's not flagging what it's not supposed to. I am also cleaning up the logic to separate the starts with lowercase check + includes newline check. In addition, I added a test to make sure that excepting interpolated string works.