### PR TITLE
Fix small typo in aria-label-is-well-formatted.md

### DIFF
--- a/docs/rules/accessibility/aria-label-is-well-formatted.md
+++ b/docs/rules/accessibility/aria-label-is-well-formatted.md
@@ -62,5 +62,5 @@ If you determine that there are valid scenarios for `aria-label` to start with l
 ````
 
 ```erb
-<a href="https://github.com/shopify/erb-lint"> aria-label="Shopify/erb-lint on GitHub"></a>
+<a href="https://github.com/shopify/erb-lint" aria-label="Shopify/erb-lint on GitHub"></a>
 ```

--- a/docs/rules/accessibility/aria-label-is-well-formatted.md
+++ b/docs/rules/accessibility/aria-label-is-well-formatted.md
@@ -48,7 +48,7 @@ If you determine that there are valid scenarios for `aria-label` to start with l
 ```
 
 ```erb
-<a href="https://github.com/shopify/erb-lint"> aria-label="github.com/shopify/erb-lint"></a>
+<a href="https://github.com/shopify/erb-lint" aria-label="github.com/shopify/erb-lint"></a>
 ```
 
 ### **Correct** code for this rule  👍


### PR DESCRIPTION
Noticed a small typo in the anchor examples of the docs:
```html
<a href="https://github.com/shopify/erb-lint"> aria-label="Shopify/erb-lint on GitHub"></a>
```

However, the anchor is closed before the aria-label attribute, so I changed it to:
```html
<a href="https://github.com/shopify/erb-lint" aria-label="Shopify/erb-lint on GitHub"></a>
```