### PR TITLE
chore: remove counter-related code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,34 +73,6 @@ linters:
 - [GitHub::Accessibility::NoTitleAttribute](./docs/rules/accessibility/no-title-attribute.md)
 - [GitHub::Accessibility::SvgHasAccessibleText](./docs/rules/accessibility/svg-has-accessible-text.md)
 
-## Disabling a rule (Deprecated)
-
-_This is a soon-to-be deprecated feature. Do not use. See [migration guide](./docs/counter-migration-guide.md)_
-
-`erblint` does not natively support rule disables. At GitHub, we've implemented these rules in a way to allow rules to be disabled at an offense-level via counters or disabled at a file-level because often times, we want to enable a rule but aren't able to address all offenses at once. We achieve this in one of two ways.
-
-Rules that are marked as `Counter` can be disabled by adding a comment with the offense count that matches the number of offenses within the file like:
-
-```.html.erb
-<%# erblint:counter GitHub::Accessibility::LinkHasHrefCounter 1 %>
-```
-
-In this comment example, when a new `LinkHasHref` offense has been added, the counter will need to be bumped up to 2. More recent rules use a `Counter` format.
-
-If you are enabling a rule for the first time and your codebase has a lot of offenses, you can use the `-a` command to automatically add these counter comments in the appropriate places.
-
-```
-bundle exec erblint app/views app/components -a
-```
-
-Rules that are not marked as `Counter` like `NoRedundantImageAlt` are considered to be legacy format. We are in the process of migrating these to counters. These rules can still be disabled at the file-level by adding this comment at the top of the file:
-
-```.html.erb
-<%# erblint:disable GitHub::Accessibility::NoRedundantImageAlt %>
-```
-
-However, unlike a counter, any subsequent offenses introduced to the file will not raise. 
-
 ## Testing
 
 ```

--- a/docs/counter-migration-guide.md
+++ b/docs/counter-migration-guide.md
@@ -1,5 +1,7 @@
 # Counter migration guide
 
+This is relevant for `erblint-github` versions <= 0.3.2.
+
 [ERBLint v0.4.0](https://github.com/Shopify/erb-lint/releases/tag/v0.4.0) introduces support for inline lint rule disables.
 
 Since an inline disable feature is now natively available, it is time to move away from the in-house (hacky) counter system we've used internally over the years and in this library. 🎉

--- a/lib/erblint-github/linters/custom_helpers.rb
+++ b/lib/erblint-github/linters/custom_helpers.rb
@@ -8,39 +8,6 @@ module ERBLint
     module CustomHelpers
       INTERACTIVE_ELEMENTS = %w[button summary input select textarea a].freeze
 
-      def counter_correct?(processed_source)
-        comment_node = nil
-        expected_count = 0
-        rule_name = simple_class_name
-        offenses_count = @offenses.length
-
-        processed_source.parser.ast.descendants(:erb).each do |node|
-          indicator_node, _, code_node, = *node
-          indicator = indicator_node&.loc&.source
-          comment = code_node&.loc&.source&.strip
-
-          if indicator == "#" && comment.start_with?("erblint:counter") && comment.match(rule_name)
-            comment_node = node
-            expected_count = comment.match(/\s(\d+)\s?$/)[1].to_i
-          end
-        end
-
-        if offenses_count.zero?
-          # have to adjust to get `\n` so we delete the whole line
-          add_offense(processed_source.to_source_range(comment_node.loc.adjust(end_pos: 1)), "Unused erblint:counter comment for #{rule_name}", "") if comment_node
-          return
-        end
-
-        first_offense = @offenses[0]
-
-        if comment_node.nil?
-          add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:disable #{rule_name} %> at the end of the offending line to bypass this check. See https://github.com/shopify/erb-lint#disable-rule-at-offense-level", "<%# erblint:disable #{rule_name} %>")
-        else
-          clear_offenses
-          add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", "<%# erblint:counter #{rule_name}Counter #{offenses_count} %>") if expected_count != offenses_count
-        end
-      end
-
       def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
         message ||= klass::MESSAGE
         message += "\nLearn more at https://github.com/github/erblint-github#rules.\n"

--- a/lib/erblint-github/linters/github/accessibility/avoid_both_disabled_and_aria_disabled.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_both_disabled_and_aria_disabled.rb
@@ -13,11 +13,6 @@ module ERBLint
           ELEMENTS_WITH_NATIVE_DISABLED_ATTRIBUTE_SUPPORT = %w[button fieldset input optgroup option select textarea].freeze
           MESSAGE = "[aria-disabled] may be used in place of native HTML [disabled] to allow tab-focus on an otherwise ignored element. Setting both attributes is contradictory."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.closing?
@@ -25,10 +20,6 @@ module ERBLint
               next unless tag.attributes["disabled"] && tag.attributes["aria-disabled"]
 
               generate_offense(self.class, processed_source, tag)
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text.rb
+++ b/lib/erblint-github/linters/github/accessibility/avoid_generic_link_text.rb
@@ -22,11 +22,6 @@ module ERBLint
 
           MESSAGE = "Avoid using generic link text such as #{BANNED_GENERIC_TEXT.join(', ')} which do not make sense in isolation."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             processed_source.ast.children.each_with_index do |node, index|
               next unless node.methods.include?(:type) && node.type == :text
@@ -97,9 +92,6 @@ module ERBLint
                 end
                 banned_text = nil
               end
-            end
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
 

--- a/lib/erblint-github/linters/github/accessibility/disabled_attribute.rb
+++ b/lib/erblint-github/linters/github/accessibility/disabled_attribute.rb
@@ -13,16 +13,6 @@ module ERBLint
           VALID_DISABLED_TAGS = %w[button input textarea option select fieldset optgroup task-lists].freeze
           MESSAGE = "`disabled` is only valid on #{VALID_DISABLED_TAGS.join(', ')}."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.closing?
@@ -30,10 +20,6 @@ module ERBLint
               next if tag.attributes["disabled"].nil?
 
               generate_offense(self.class, processed_source, tag)
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/iframe_has_title.rb
+++ b/lib/erblint-github/linters/github/accessibility/iframe_has_title.rb
@@ -13,11 +13,6 @@ module ERBLint
           MESSAGE = "`<iframe>` with meaningful content should have a title attribute that identifies the content."\
                     " If `<iframe>` has no meaningful content, hide it from assistive technology with `aria-hidden='true'`."\
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.name != "iframe"
@@ -26,10 +21,6 @@ module ERBLint
               title = possible_attribute_values(tag, "title")
 
               generate_offense(self.class, processed_source, tag) if title.empty? && !aria_hidden?(tag)
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
 

--- a/lib/erblint-github/linters/github/accessibility/image_has_alt.rb
+++ b/lib/erblint-github/linters/github/accessibility/image_has_alt.rb
@@ -12,11 +12,6 @@ module ERBLint
 
           MESSAGE = "<img> should have an alt prop with meaningful text or an empty string for decorative images"
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.name != "img"
@@ -25,10 +20,6 @@ module ERBLint
               alt = possible_attribute_values(tag, "alt")
 
               generate_offense(self.class, processed_source, tag) if alt.empty?
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/link_has_href.rb
+++ b/lib/erblint-github/linters/github/accessibility/link_has_href.rb
@@ -12,11 +12,6 @@ module ERBLint
 
           MESSAGE = "Links should go somewhere, you probably want to use a `<button>` instead."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.name != "a"
@@ -25,10 +20,6 @@ module ERBLint
               href = possible_attribute_values(tag, "href")
               name = tag.attributes["name"]
               generate_offense(self.class, processed_source, tag) if (!name && href.empty?) || href.include?("#")
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/nested_interactive_elements.rb
+++ b/lib/erblint-github/linters/github/accessibility/nested_interactive_elements.rb
@@ -12,10 +12,6 @@ module ERBLint
 
           MESSAGE = "Nesting interactive elements produces invalid HTML, and ssistive technologies, such as screen readers, might ignore or respond unexpectedly to such nested controls."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
           def run(processed_source)
             last_interactive_element = nil
             tags(processed_source).each do |tag|
@@ -33,10 +29,6 @@ module ERBLint
               end
 
               last_interactive_element = tag unless tag&.name == "input"
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/no_aria_hidden_on_focusable.rb
+++ b/lib/erblint-github/linters/github/accessibility/no_aria_hidden_on_focusable.rb
@@ -12,19 +12,10 @@ module ERBLint
 
           MESSAGE = "Elements that are focusable should not have `aria-hidden='true' because it will cause confusion for assistive technology users."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               aria_hidden = possible_attribute_values(tag, "aria-hidden")
               generate_offense(self.class, processed_source, tag) if aria_hidden.include?("true") && focusable?(tag)
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/no_aria_label_misuse.rb
+++ b/lib/erblint-github/linters/github/accessibility/no_aria_label_misuse.rb
@@ -18,11 +18,6 @@ module ERBLint
 
           MESSAGE = "[aria-label] and [aria-labelledby] usage are only reliably supported on interactive elements and a subset of ARIA roles"
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.closing?
@@ -38,9 +33,6 @@ module ERBLint
                   generate_offense(self.class, processed_source, tag)
                 end
               end
-            end
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/no_positive_tab_index.rb
+++ b/lib/erblint-github/linters/github/accessibility/no_positive_tab_index.rb
@@ -12,21 +12,12 @@ module ERBLint
 
           MESSAGE = "Do not use positive tabindex as it is error prone and can severely disrupt navigation experience for keyboard users"
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.closing?
               next unless tag.attributes["tabindex"]&.value.to_i.positive?
 
               generate_offense(self.class, processed_source, tag)
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/no_redundant_image_alt.rb
+++ b/lib/erblint-github/linters/github/accessibility/no_redundant_image_alt.rb
@@ -13,11 +13,6 @@ module ERBLint
           MESSAGE = "<img> alt prop should not contain `image` or `picture` as screen readers already announce the element as an image"
           REDUNDANT_ALT_WORDS = %w[image picture].freeze
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.name != "img"
@@ -27,10 +22,6 @@ module ERBLint
               next if alt.empty?
 
               generate_offense(self.class, processed_source, tag) if (alt.downcase.split & REDUNDANT_ALT_WORDS).any?
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/no_title_attribute.rb
+++ b/lib/erblint-github/linters/github/accessibility/no_title_attribute.rb
@@ -12,11 +12,6 @@ module ERBLint
 
           MESSAGE = "The title attribute should never be used unless for an `<iframe>` as it is inaccessible for several groups of users."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             tags(processed_source).each do |tag|
               next if tag.name == "iframe"
@@ -24,10 +19,6 @@ module ERBLint
 
               title = possible_attribute_values(tag, "title")
               generate_offense(self.class, processed_source, tag) if title.present?
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/lib/erblint-github/linters/github/accessibility/svg_has_accessible_text.rb
+++ b/lib/erblint-github/linters/github/accessibility/svg_has_accessible_text.rb
@@ -12,11 +12,6 @@ module ERBLint
 
           MESSAGE = "`<svg>` must have accessible text. Set `aria-label`, or `aria-labelledby`, or nest a `<title>` element. However, if the `<svg>` is purely decorative, hide it with `aria-hidden='true'.\nFor more info, see https://css-tricks.com/accessible-svgs/."
 
-          class ConfigSchema < LinterConfig
-            property :counter_enabled, accepts: [true, false], default: false, reader: :counter_enabled?
-          end
-          self.config_schema = ConfigSchema
-
           def run(processed_source)
             current_svg = nil
             has_accessible_label = false
@@ -40,10 +35,6 @@ module ERBLint
 
                 has_accessible_label = aria_label.present? || aria_labelledby.present?
               end
-            end
-
-            if @config.counter_enabled?
-              counter_correct?(processed_source)
             end
           end
         end

--- a/test/custom_helpers_test.rb
+++ b/test/custom_helpers_test.rb
@@ -20,35 +20,6 @@ class CustomHelpersTest < LinterTestCase
     @linter.extend(ERBLint::Linters::CustomHelpers)
   end
 
-  def test_counter_correct_does_not_add_offense_if_counter_matches_offense_count
-    @file = <<~HTML
-      <%# erblint:counter CustomHelpersTest::FakeLinter 1 %>
-    HTML
-    @linter.offenses = ["fake offense"]
-
-    extended_linter.counter_correct?(processed_source)
-    assert_empty @linter.offenses
-  end
-
-  def test_counter_correct_add_offense_if_counter_comment_is_unused
-    @file = <<~HTML
-      <%# erblint:counter CustomHelpersTest::FakeLinter 1 %>
-    HTML
-
-    extended_linter.counter_correct?(processed_source)
-    assert_equal "Unused erblint:counter comment for CustomHelpersTest::FakeLinter", @linter.offenses.first.message
-  end
-
-  def test_counter_correct_add_offense_if_counter_comment_count_is_incorrect
-    @file = <<~HTML
-      <%# erblint:counter CustomHelpersTest::FakeLinter 2 %>
-    HTML
-    @linter.offenses = ["fake offense"]
-
-    extended_linter.counter_correct?(processed_source)
-    assert_equal "Incorrect erblint:counter number for CustomHelpersTest::FakeLinter. Expected: 2, actual: 1.", @linter.offenses.first.message
-  end
-
   def test_generate_offense_with_message_defined_in_linter_class
     @file = <<~HTML
       <%# erblint:disable CustomHelpersTest::FakeLinter %>

--- a/test/linters/accessibility/avoid_both_disabled_and_aria_disabled_test.rb
+++ b/test/linters/accessibility/avoid_both_disabled_and_aria_disabled_test.rb
@@ -35,25 +35,4 @@ class AvoidBothDisabledAndAriaDisabledTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_adds_extra_offense_to_add_counter_comment_if_counter_config_enabled
-    @file = ELEMENTS_WITH_NATIVE_DISABLED_ATTRIBUTE_SUPPORT.map do |element|
-      "<#{element} aria-disabled='true' disabled> </#{element}>"
-    end.join
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-
-    assert_equal @linter.offenses.count, 8
-    assert_match(/If you must, add <%# erblint:disable GitHub::Accessibility::AvoidBothDisabledAndAriaDisabled %> at the end of the offending line to bypass this check./, @linter.offenses.last.message)
-  end
-
-  def test_does_not_raise_when_ignore_comment_with_correct_count_if_counter_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::AvoidBothDisabledAndAriaDisabledCounter 1 %>
-      <button disabled aria-disabled="true">Some text</button>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-    assert_empty @linter.offenses
-  end
 end

--- a/test/linters/accessibility/avoid_generic_link_text_test.rb
+++ b/test/linters/accessibility/avoid_generic_link_text_test.rb
@@ -144,15 +144,4 @@ class AvoidGenericLinkTextTest < LinterTestCase
     refute_empty @linter.offenses
     assert_equal 3, @linter.offenses.count
   end
-
-  def test_does_not_warns_if_element_has_correct_counter_comment_if_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::AvoidGenericLinkTextCounter 1 %>
-      <a>Link</a>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-
-    assert_equal 0, @linter.offenses.count
-  end
 end

--- a/test/linters/accessibility/disabled_attribute_test.rb
+++ b/test/linters/accessibility/disabled_attribute_test.rb
@@ -22,15 +22,4 @@ class DisabledAttributeTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_warns_if_element_has_correct_counter_comment_if_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::DisabledAttributeCounter 1 %>
-      <a href='https://github.com/' disabled>Go to GitHub</a>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-
-    assert_equal 0, @linter.offenses.count
-  end
 end

--- a/test/linters/accessibility/iframe_has_title_test.rb
+++ b/test/linters/accessibility/iframe_has_title_test.rb
@@ -27,14 +27,4 @@ class IframeHasTitleTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_raise_when_ignore_comment_with_correct_count_if_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::IframeHasTitleCounter 1 %>
-      <iframe></iframe>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-    assert_empty @linter.offenses
-  end
 end

--- a/test/linters/accessibility/image_has_alt_test.rb
+++ b/test/linters/accessibility/image_has_alt_test.rb
@@ -27,14 +27,4 @@ class ImageHasAltTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_raise_when_ignore_comment_with_correct_count_if_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::ImageHasAltCounter 1 %>
-      <img></img>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-    assert_empty @linter.offenses
-  end
 end

--- a/test/linters/accessibility/link_has_href_test.rb
+++ b/test/linters/accessibility/link_has_href_test.rb
@@ -22,15 +22,4 @@ class LinkHasHrefTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_warn_if_link_has_href_attribute_and_has_correct_counter_comment
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::LinkHasHrefCounter 1 %>
-      <a>Go to GitHub</a>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-
-    assert_equal 0, @linter.offenses.count
-  end
 end

--- a/test/linters/accessibility/nested_interactive_elements_test.rb
+++ b/test/linters/accessibility/nested_interactive_elements_test.rb
@@ -22,15 +22,4 @@ class NestedInteractiveElementsTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_warn_if_there_are_not_nested_interactive_elements_and_has_correct_counter_comment_with_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::NestedInteractiveElementsCounter 1 %>
-      <button><a href='https://github.com/'>Go to GitHub</a></button>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-
-    assert_equal 0, @linter.offenses.count
-  end
 end

--- a/test/linters/accessibility/no_aria_label_misuse_test.rb
+++ b/test/linters/accessibility/no_aria_label_misuse_test.rb
@@ -74,15 +74,4 @@ class NoAriaLabelMisuseTest < LinterTestCase
     @linter.run(processed_source)
     assert_empty @linter.offenses
   end
-
-  def test_does_not_raise_when_ignore_comment_with_correct_count_and_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::NoAriaLabelMisuseCounter 2 %>
-      <span aria-label="This is a bad idea">Some text</span>
-      <span aria-label="This is still a bad idea">More text</span>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-    assert_empty @linter.offenses
-  end
 end

--- a/test/linters/accessibility/no_positive_tab_index_test.rb
+++ b/test/linters/accessibility/no_positive_tab_index_test.rb
@@ -27,14 +27,4 @@ class NoPositiveTabIndexTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_raise_when_ignore_comment_with_correct_count_and_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::NoPositiveTabIndexCounter 1 %>
-      <button tabindex='1'></button>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-    assert_empty @linter.offenses
-  end
 end

--- a/test/linters/accessibility/no_redundant_image_alt_test.rb
+++ b/test/linters/accessibility/no_redundant_image_alt_test.rb
@@ -27,15 +27,4 @@ class NoRedundantImageAltTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_raise_when_ignore_comment_with_correct_count_and_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::NoRedundantImageAltCounter 1 %>
-      <img alt='image of an octopus'></img>
-    ERB
-
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-    assert_empty @linter.offenses
-  end
 end

--- a/test/linters/accessibility/no_title_attribute_test.rb
+++ b/test/linters/accessibility/no_title_attribute_test.rb
@@ -7,24 +7,13 @@ class NoTitleAttributeTest < LinterTestCase
     ERBLint::Linters::GitHub::Accessibility::NoTitleAttribute
   end
 
-  def test_warns_if_element_sets_title_and_has_no_counter_comment
+  def test_warns_if_element_sets_title
     @file = "<img title='octopus'></img>"
     @linter.run(processed_source)
 
     assert_equal(1, @linter.offenses.count)
     error_messages = @linter.offenses.map(&:message).sort
     assert_match(/The title attribute should never be used unless for an `<iframe>` as it is inaccessible for several groups of users./, error_messages.last)
-  end
-
-  def test_does_not_warns_if_element_sets_title_and_has_correct_counter_comment_if_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::NoTitleAttributeCounter 1 %>
-      <a href="/" title="bad">some website</a>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-
-    assert_equal 0, @linter.offenses.count
   end
 
   def test_does_not_warn_if_iframe_sets_title

--- a/test/linters/accessibility/svg_has_accessible_text_test.rb
+++ b/test/linters/accessibility/svg_has_accessible_text_test.rb
@@ -31,15 +31,4 @@ class SvgHasAccessibleText < LinterTestCase
 
     assert_empty @linter.offenses
   end
-
-  def test_does_not_warn_if_svg_has_accesible_text_and_has_correct_counter_comment_if_config_enabled
-    @file = <<~ERB
-      <%# erblint:counter GitHub::Accessibility::SvgHasAccessibleTextCounter 1 %>
-      <svg height='100' width='100'><circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red'/></svg>
-    ERB
-    @linter.config.counter_enabled = true
-    @linter.run(processed_source)
-
-    assert_equal 0, @linter.offenses.count
-  end
 end


### PR DESCRIPTION
Fixes: https://github.com/github/erblint-github/issues/74

This PR completely removes the counter-system related code, which was moved to deprecation status in v0.2.0. 

We've supported enabling the counter system on a per rule basis to [ease migration](https://github.com/github/erblint-github/blob/main/docs/counter-migration-guide.md) but now that we're a few versions in, let's completely deprecate it.