### PR TITLE
Temporarily introduce back counter_correct? helper

### DIFF
--- a/lib/erblint-github/linters/custom_helpers.rb
+++ b/lib/erblint-github/linters/custom_helpers.rb
@@ -27,6 +27,39 @@ module ERBLint
         [value].compact
       end
 
+      def counter_correct?(processed_source)
+        comment_node = nil
+        expected_count = 0
+        rule_name = self.class.name.gsub("ERBLint::Linters::", "")
+        offenses_count = @offenses.length
+
+        processed_source.parser.ast.descendants(:erb).each do |node|
+          indicator_node, _, code_node, = *node
+          indicator = indicator_node&.loc&.source
+          comment = code_node&.loc&.source&.strip
+
+          if indicator == "#" && comment.start_with?("erblint:counter") && comment.match(rule_name)
+            comment_node = node
+            expected_count = comment.match(/\s(\d+)\s?$/)[1].to_i
+          end
+        end
+
+        if offenses_count.zero?
+          # have to adjust to get `\n` so we delete the whole line
+          add_offense(processed_source.to_source_range(comment_node.loc.adjust(end_pos: 1)), "Unused erblint:counter comment for #{rule_name}", "") if comment_node
+          return
+        end
+
+        first_offense = @offenses[0]
+
+        if comment_node.nil?
+          add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:counter #{rule_name} #{offenses_count} %> to bypass this check.", "<%# erblint:counter #{rule_name} #{offenses_count} %>")
+        else
+          clear_offenses
+          add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", "<%# erblint:counter #{rule_name} #{offenses_count} %>") if expected_count != offenses_count
+        end
+      end
+
       # Map possible values from condition
       def basic_conditional_code_check(code)
         conditional_match = code.match(/["'](.+)["']\sif|unless\s.+/) || code.match(/.+\s?\s["'](.+)["']\s:\s["'](.+)["']/)


### PR DESCRIPTION
This PR _temporarily_ introduces back the `counter_correct?` helper which was removed in a recent PR.

One of our project pulls in both `erblint-github` and `primer_view_components`. The latter has a custom rule which pulls in the `counter_correct?` helper from this gem.

This means that projects that use `primer_view_components` are blocked on upgrading `erblint_github` due to the lint rule in `primer_view_components` depending on this `counter_correct?` helper.

I've since removed the dependency on `erblint-github` from `primer_view_components` in https://github.com/primer/view_components/pull/2067, but until there's a new version of `primer_view_components` for consumers, I'd like to temporarily keep this custom helper in this gem.