### PR TITLE
Update accessibility.yml recommended configs.

### DIFF
--- a/config/accessibility.yml
+++ b/config/accessibility.yml
@@ -1,5 +1,7 @@
 ---
 linters:
+  NoUnusedDisable:
+    enabled: true
   GitHub::Accessibility::AriaLabelIsWellFormatted:
     enabled: true
   GitHub::Accessibility::AvoidBothDisabledAndAriaDisabled:


### PR DESCRIPTION
The `NoUnusedDisable` rule should be on by default in our recommended configs.

This rule flags when a disable comment is no longer necessary.