### PR TITLE
Add `erblint-disable` script from dotcom and friends.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erblint-github (0.4.2)
+    erblint-github (0.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erblint-github (0.4.1)
+    erblint-github (0.4.2)
 
 GEM
   remote: https://rubygems.org/

--- a/bin/erblint-disable
+++ b/bin/erblint-disable
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+
+# Accepts comma-separated args with simple rule name
+# e.g. script/erblint-disable SomeRule1,SomeRule2
+# e.g. script/erblint-disable GitHub::Accessibility::Rule1,SomeRule2
+rules = ARGV[0]
+
+rules_array = rules.split(",")
+rules_map = {}
+rules_array.each do |rule|
+  rule_underscored = rule.to_s.gsub(/::/, "/").
+    gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
+    gsub(/([a-z\d])([A-Z])/, '\1_\2').
+    tr("-", "_").
+    downcase.
+    gsub("git_hub", "github") # corrects rule names with `GitHub` name to align with erb-lint expectations
+  rules_map[rule] = rule_underscored
+end
+
+rules_map.each do |disable_comment_name, command_line_name|
+  output = `bin/erblint --format json --enable-linters #{command_line_name} app/views app/components packages/**/app/components app/forms/**/`
+  hashed_output = JSON.parse(output)
+  hashed_output["files"].each do |file|
+    path = file["path"]
+    offenses = file["offenses"]
+    line_numbers = offenses.map do |offense|
+      offense["location"]["last_line"]
+    end
+    File.open(path, "r+") do |file|
+      lines = file.each_line.to_a
+      line_numbers.each do |line_number|
+        line = lines[line_number - 1]
+        unless line.match?(/erblint:disable (?<rules>.*#{disable_comment_name}).*/)
+          existing_disable = line.match(/(?<=# erblint:disable)(.*) (?=%>)/)
+          if existing_disable
+            existing_disable_string = existing_disable.captures[0]
+            add_new_disable = "#{existing_disable_string}, #{disable_comment_name}"
+            lines[line_number - 1] = lines[line_number - 1].gsub(existing_disable_string, add_new_disable)
+          else
+            lines[line_number - 1] = lines[line_number - 1].gsub("\n", "") + "<%# erblint:disable #{disable_comment_name} %>\n"
+          end
+        end
+      end
+      file.rewind
+      file.write(lines.join)
+    end
+  end
+end
+
+exit 0

--- a/bin/erblint-disable
+++ b/bin/erblint-disable
@@ -11,7 +11,7 @@ rules = ARGV[0]
 rules_array = rules.split(",")
 rules_map = {}
 rules_array.each do |rule|
-  rule_underscored = rule.to_s.gsub(/::/, "/").
+  rule_underscored = rule.to_s.gsub("::", "/").
     gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
     gsub(/([a-z\d])([A-Z])/, '\1_\2').
     tr("-", "_").

--- a/erblint-github.gemspec
+++ b/erblint-github.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "erblint-github"
-  s.version = "0.4.1"
+  s.version = "0.4.2"
   s.summary = "erblint GitHub"
   s.description = "Template style checking for GitHub Ruby repositories"
   s.homepage = "https://github.com/github/erblint-github"

--- a/erblint-github.gemspec
+++ b/erblint-github.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop", "= 1.54.2"
   s.add_development_dependency "rubocop-github", "~> 0.20.0"
   s.metadata["rubygems_mfa_required"] = "true"
+
+  s.executables << "erblint-disable"
 end

--- a/erblint-github.gemspec
+++ b/erblint-github.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "erblint-github"
-  s.version = "0.4.2"
+  s.version = "0.4.1"
   s.summary = "erblint GitHub"
   s.description = "Template style checking for GitHub Ruby repositories"
   s.homepage = "https://github.com/github/erblint-github"


### PR DESCRIPTION
Related to https://github.com/github/accessibility/issues/3825.

This script will be able to be run from any project that includes it by running `bundle exec erblint-disable ...`.

Will need to follow up with PRs to dotcom, classroom and education-web to remove the script that is currently in those repos.