### PR TITLE
Update navigation-has-label docs

### DIFF
--- a/docs/rules/accessibility/navigation-has-label.md
+++ b/docs/rules/accessibility/navigation-has-label.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule enforces that a navigation landmark (a `<nav>` or a `role="navigation"`) has an accessible name. This rule is helpful for sites (like GitHub) where multiple navigation is common.
+This rule enforces that a navigation landmark (a `<nav>` or a `role="navigation"`) has an accessible name. This rule is helpful for sites (like GitHub) where multiple navigation elements is common.
 
 An accessible name ensures that one can distinguish between multiple navigation elements.
 

--- a/docs/rules/accessibility/navigation-has-label.md
+++ b/docs/rules/accessibility/navigation-has-label.md
@@ -2,9 +2,11 @@
 
 ## Rule Details
 
-This rule enforces that a navigation landmark (a `<nav>` or a `role="navigation"`) has an accessible name. This rule is helpful to enforce for sites (like GitHub) where multiple navigation is common.
+This rule enforces that a navigation landmark (a `<nav>` or a `role="navigation"`) has an accessible name. This rule is helpful for sites (like GitHub) where multiple navigation is common.
 
-The navigation landmark element should have an `aria-label` attribute, or `aria-labelledby` to distinguish it from other elements.
+An accessible name ensures that one can distinguish between multiple navigation elements.
+
+If the navigation area begins with a heading, use the heading to label the navigation element using the `aria-labelledby` attribute. If there is no heading, then you may set `aria-label`. Make sure to format the text the same way you should visual text (Related: [aria-label is well formatted](./aria-label-is-well-formatted.md)).
 
 ## Resources
 
@@ -24,7 +26,15 @@ The navigation landmark element should have an `aria-label` attribute, or `aria-
 
 ```erb
 <!-- correct -->
-<nav aria-labelledby="title_id"t>
-  <h1 id="title_id">This is a text</h1>
+<nav aria-labelledby="title_id">
+  <h1 id="title_id">Setings</h1>
+  ...
+</nav>
+```
+
+```erb
+<!-- correct -->
+<nav aria-label="Repos">
+  ...
 </nav>
 ```

--- a/docs/rules/accessibility/navigation-has-label.md
+++ b/docs/rules/accessibility/navigation-has-label.md
@@ -6,7 +6,7 @@ This rule enforces that a navigation landmark (a `<nav>` or a `role="navigation"
 
 An accessible name ensures that one can distinguish between multiple navigation elements.
 
-If the navigation area begins with a heading, use the heading to label the navigation element using the `aria-labelledby` attribute. If there is no heading, then you may set `aria-label`. Make sure to format the text the same way you should visual text (Related: [aria-label is well formatted](./aria-label-is-well-formatted.md)).
+If the navigation area begins with a heading, use the heading to label the navigation element using the `aria-labelledby` attribute. If there is no heading, then you may set `aria-label`. Make sure to format the text the same way you would visual text (Related: [aria-label is well formatted](./aria-label-is-well-formatted.md)).
 
 ## Resources
 


### PR DESCRIPTION
Making clear that `aria-labelledby` to a heading is preferred where possible.