### PR TITLE
Don't flag `title` on link tag

### DIFF
--- a/docs/rules/accessibility/no-title-attribute.md
+++ b/docs/rules/accessibility/no-title-attribute.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-The `title` attribute is strongly discouraged. The only exception is on an `<iframe>` element. It is hardly useful and cannot be accessed by multiple groups of users including keyboard-only users and mobile users.
+The `title` attribute is strongly discouraged. The only exceptions are for `<link>` and `<iframe>` element. It is hardly useful and cannot be accessed by multiple groups of users including keyboard-only users and mobile users.
 
 The `title` attribute is commonly seen set on links, matching the link text. This is redundant and unnecessary so it can be simply be removed.
 

--- a/lib/erblint-github/linters/github/accessibility/no_title_attribute.rb
+++ b/lib/erblint-github/linters/github/accessibility/no_title_attribute.rb
@@ -10,11 +10,11 @@ module ERBLint
           include ERBLint::Linters::CustomHelpers
           include LinterRegistry
 
-          MESSAGE = "The title attribute should never be used unless for an `<iframe>` as it is inaccessible for several groups of users."
+          MESSAGE = "The title attribute should never be used as it is inaccessible for several groups of users. Exceptions are <iframe> and <link>."
 
           def run(processed_source)
             tags(processed_source).each do |tag|
-              next if tag.name == "iframe"
+              next if tag.name == "iframe" || tag.name == "link"
               next if tag.closing?
 
               title = possible_attribute_values(tag, "title")

--- a/lib/erblint-github/linters/github/accessibility/no_title_attribute.rb
+++ b/lib/erblint-github/linters/github/accessibility/no_title_attribute.rb
@@ -10,7 +10,7 @@ module ERBLint
           include ERBLint::Linters::CustomHelpers
           include LinterRegistry
 
-          MESSAGE = "The title attribute should never be used as it is inaccessible for several groups of users. Exceptions are <iframe> and <link>."
+          MESSAGE = "The title attribute should never be used as it is inaccessible for several groups of users. Exceptions are provided for <iframe> and <link>."
 
           def run(processed_source)
             tags(processed_source).each do |tag|

--- a/test/linters/accessibility/no_title_attribute_test.rb
+++ b/test/linters/accessibility/no_title_attribute_test.rb
@@ -22,4 +22,11 @@ class NoTitleAttributeTest < LinterTestCase
 
     assert_empty @linter.offenses
   end
+
+  def test_does_not_warn_if_link_sets_title
+    @file = "<link rel='unapi-server' type='application/xml' title='unAPI' href='/unapi'/></link>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
 end

--- a/test/linters/accessibility/no_title_attribute_test.rb
+++ b/test/linters/accessibility/no_title_attribute_test.rb
@@ -13,7 +13,7 @@ class NoTitleAttributeTest < LinterTestCase
 
     assert_equal(1, @linter.offenses.count)
     error_messages = @linter.offenses.map(&:message).sort
-    assert_match(/The title attribute should never be used unless for an `<iframe>` as it is inaccessible for several groups of users./, error_messages.last)
+    assert_match(/The title attribute should never be used as it is inaccessible for several groups of users./, error_messages.last)
   end
 
   def test_does_not_warn_if_iframe_sets_title


### PR DESCRIPTION
Fixes: https://github.com/github/erblint-github/issues/108

It seems reasonable to not flag the `<link>` tag given it's NOT user-facing and [title has special semantics on the link element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#title) to define a default or an alternate stylesheet.