### PR TITLE
Auto approve and merge dependabot updates

### DIFF
--- a/.github/workflows/auto-approve-and-merge.yml
+++ b/.github/workflows/auto-approve-and-merge.yml
@@ -1,0 +1,28 @@
+name: Auto-approve and merge PR
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto_approve:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Approve PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.pulls.createReview({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number,
+              event: "APPROVE",
+            })
+      - name: Enable auto-merge for PR
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Effort to reduce FR burden by auto approving and merging dependabot updates that pass all checks. We can always review these when it's time to cut a release too.