### PR TITLE
Remove unused helper method

### DIFF
--- a/lib/erblint-github/linters/custom_helpers.rb
+++ b/lib/erblint-github/linters/custom_helpers.rb
@@ -60,12 +60,6 @@ module ERBLint
         end
       end
 
-      # Map possible values from condition
-      def basic_conditional_code_check(code)
-        conditional_match = code.match(/["'](.+)["']\sif|unless\s.+/) || code.match(/.+\s?\s["'](.+)["']\s:\s["'](.+)["']/)
-        [conditional_match[1], conditional_match[2]].compact if conditional_match
-      end
-
       def tags(processed_source)
         processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
       end


### PR DESCRIPTION
Fixes: https://github.com/github/erblint-github/security/code-scanning/2
Fixes: https://github.com/github/erblint-github/security/code-scanning/1

I must have ported this file over from dotcom, but this function is not used in any of our rules, and is raising a code scanning alert. 

Let's remove this!
