### PR TITLE
chore: grouped dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This PR attempts to save clicks for FR by grouping minor/major dependabot updates together. The idea is that minor/major dependabot updates are less likely to contain breaking changes, and the major changes will be opened as its own PR. If this config doesn't work for the team, we can revert it or adjust it!